### PR TITLE
Update Golang Roles Update Implementation

### DIFF
--- a/docs/sdk/golang/role/Update.mdx
+++ b/docs/sdk/golang/role/Update.mdx
@@ -21,5 +21,5 @@ roleUpdate.SetPermissions([]string{"resource-key:read", "resource-key:write"})
 ### Implementation
 
 ```go
-role, err := Permit.Api.Roles.Create(ctx, "role-key", *roleUpdate)
+role, err := Permit.Api.Roles.Update(ctx, "role-key", *roleUpdate)
 ```


### PR DESCRIPTION
Fixes a copy/paste error in the example of updating a role in the golang sdk.