### PR TITLE
Typo Updated in quickstart.mdx

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -81,7 +81,7 @@ The first step is to create a role for each user. In this example, we will creat
 ### Creating a resource and actions
 
 Once we created our role, the next step is to create a resource, and actions that we can perform on that resource. In this example
-we create a resource called a `Document` and utilize the basic pre-defined actions Permit provides (`crate`, `read`, `update` and `delete`),
+we create a resource called a `Document` and utilize the basic pre-defined actions Permit provides (`create`, `read`, `update` and `delete`),
 as well as assign our own bespoke actions: `publish`.
 
 <video controls autoPlay loop>


### PR DESCRIPTION
Typo in line 84 word ('crate') instead of 'Create'. Updated the typo