### PR TITLE
Added missing backslash to multi-line terminal command

### DIFF
--- a/docs/api/v2-migration-guide.mdx
+++ b/docs/api/v2-migration-guide.mdx
@@ -194,7 +194,7 @@ To launch a v2 PDP, simply use the existing command you have for the v1 SDK to p
 
     docker run -p 7766:7000 \
     	--env PDP_API_KEY=permit_key_abcdefghijklmnopqrstuvwxyz \
-    	--env PDP_DEBUG=True
+    	--env PDP_DEBUG=True \
     	permitio/pdp-v2:latest
 
 If you're not doing writes through the SDKs, then aside from upgrading to the new v2 SDKs and pointing them at the new v2 PDP, there's nothing you need to do. The permit.check call and the module initialization is exactly the same as in v1.

--- a/docs/how-to/deploy/deploy-to-production.mdx
+++ b/docs/how-to/deploy/deploy-to-production.mdx
@@ -29,7 +29,7 @@ Run the container & replace the `PDP_API_KEY` environment variable with your API
 docker run -it \
   -p 7766:7000 \
   --env PDP_API_KEY=<YOUR_API_KEY> \
-  --env PDP_DEBUG=True
+  --env PDP_DEBUG=True \
   permitio/pdp-v2:latest
 ```
 
@@ -57,7 +57,7 @@ docker run -it \
   -p 7766:7000 \
   -p 8181:8181 \
   --env PDP_API_KEY=<YOUR_API_KEY> \
-  --env PDP_DEBUG=True
+  --env PDP_DEBUG=True \
   permitio/pdp-v2:latest
 ```
 

--- a/docs/how-to/use-audit-logs/debug-mode.mdx
+++ b/docs/how-to/use-audit-logs/debug-mode.mdx
@@ -39,7 +39,7 @@ Here's an example of such a PDP deployment:
 docker run -it \
   -p 7766:7000 \
   --env PDP_API_KEY=<YOUR_API_KEY> \
-  --env PDP_DEBUG=True
+  --env PDP_DEBUG=True \
   permitio/pdp-v2:latest
 ```
 

--- a/docs/integrations/gateways/kong.mdx
+++ b/docs/integrations/gateways/kong.mdx
@@ -36,7 +36,7 @@ To run the PDP, you can use the following command:
 docker run \
 ⁠  -p 7766:7000 \
 ⁠  --env PDP_API_KEY=YOUR_PERMIT_API_KEY \
-  --env PDP_DEBUG=True
+  --env PDP_DEBUG=True \
 ⁠  --env PDP_KONG_INTEGRATION=true \
 ⁠  permitio/pdp-v2:latest
 ```


### PR DESCRIPTION
I noticed a broken terminal command to start the PDP in Docker (there's a missing backslash at the end of line 4) and found the missing backslash in the docs too. Here's a quick patch for the docs. Let me know if you'd like me to report the dashboard issue elsewhere. Cheers!

<img width="484" alt="image" src="https://github.com/permitio/docs/assets/76757/f458e2a7-dc1f-4ac7-9a1b-0c4d30ec4752">
