### PR TITLE
Pull all examples from public GitHub

### DIFF
--- a/src/components/GitHubExamples.jsx
+++ b/src/components/GitHubExamples.jsx
@@ -36,7 +36,7 @@ export default function GitHubExamples() {
   const [repos, setRepos] = useState([]);
 
   useEffect(() => {
-    fetch('https://api.github.com/search/repositories?q=org:permitio+example+in:name+archived:false&sort=updated&order=desc')
+    fetch('https://api.github.com/search/repositories?q=org:permitio+topic:example+archived:false&sort=updated&order=desc')
       .then(response => response.json())
       .then(data => {
         const filteredRepos = data.items.filter(repo => 

--- a/src/components/GitHubExamples.jsx
+++ b/src/components/GitHubExamples.jsx
@@ -34,16 +34,14 @@ const RepoCard = ({ repo }) => (
 
 export default function GitHubExamples() {
   const [repos, setRepos] = useState([]);
+  const perPage = 50;
 
   useEffect(() => {
-    fetch('https://api.github.com/search/repositories?q=org:permitio+topic:example+archived:false&sort=updated&order=desc')
+    fetch(`https://api.github.com/search/repositories?q=org:permitio+topic:example+archived:false&sort=updated&order=desc&per_page=${perPage}`)
       .then(response => response.json())
       .then(data => {
-        const filteredRepos = data.items.filter(repo => 
-          repo.name.toLowerCase().includes('example') || 
-          repo.name.toLowerCase().includes('demo')
-        );
-        setRepos(filteredRepos);
+        setRepos(data.items);
+        setTotalCount(data.total_count);
       })
       .catch(error => console.error('Error fetching repos:', error));
   }, []);


### PR DESCRIPTION
I noticed on the `Other Code Examples` page that it was only pulling ones that had `example` in the title. I went into GitHub and added the topic `example` to all of our public examples so that they will all show up. 

This resolves this ticket:
https://linear.app/permit/issue/PER-11980/add-all-example-to-all-example-apps-in-github