### PR TITLE
add Checking Permissions to advanced, and clarify json regex string

### DIFF
--- a/docs/foaz/url-mapping-check.mdx
+++ b/docs/foaz/url-mapping-check.mdx
@@ -55,7 +55,7 @@ By correctly setting up mapping rules, you can ensure that requests are correctl
 
 ### Checking Permissions
 
-To use the URL Mapping Permissions Check, you must first set up the PDP. You must deploy the following version of the PDP that supports the URL Mapping Check: `permitio/pdp-v2:0.2.19-rc.2`.
+To use the URL Mapping Permissions Check, you must first set up the PDP. You must deploy the following version of the PDP that supports the URL Mapping Check: `pdp-v2:0.2.19-rc.2 or higher`.
 
 Currently, checking permissions using URL Mapping is available through the endpoint `/allowed_url` on the PDP. The SDKs will be updated to support this feature soon.
 
@@ -113,6 +113,12 @@ curl --location 'https://api.permit.io/v2/facts/{project_id}/{env_id}/proxy_conf
 }'
 ```
 
+:::danger
+
+Noitce in the API call, the regex pattern is being sent as a JSON string. In JSON, backslashes need to be escaped themselves, so `\.` becomes `\\.` in the JSON payload.
+
+:::
+
 Key points about this configuration:
 - The `url_type` must be set to `"regex"` to enable regex pattern matching
 - The regex pattern uses named capture groups (`?P<name>pattern`) to extract values
@@ -123,6 +129,30 @@ Key points about this configuration:
 The `secret` value is still required for now, even though it isn't used. This will be fixed in a future relase of the proxy_configs API.
 :::
 
+### Checking Permissions
+
+To use the Advanced URL Mapping Permissions Check, you must first set up the PDP. You must deploy the following version of the PDP that supports the URL Mapping Check: `permitio/pdp-v2:0.8.0-rc.1 or higher`.
+
+Currently, checking permissions using URL Mapping is available through the endpoint `/allowed_url` on the PDP. The SDKs will be updated to support this feature soon.
+
+Here's an example of a payload to `localhost:7766/allowed_url` (assuming you're running the PDP locally):
+
+```bash
+curl --location 'http://localhost:7766/allowed_url' \
+--header 'Content-Type: application/json' \
+--header 'Accept: application/json' \
+--header 'Authorization: Bearer permit_key_{your_key}' \
+--data '{
+  "user": {
+    "key": "raz@permit.io"
+  },
+  "url": "https://api.example.com/users/123/profile",
+  "http_method": "post",
+  "tenant": "default"
+}'
+
+```
+
 ### Common Regex Patterns
 
 <TimelineWrapper>
@@ -130,8 +160,9 @@ The `secret` value is still required for now, even though it isn't used. This wi
 
 
 #### Basic Path Parameter
-```regex
-^https://api\.example\.com/users/(?P<user_id>[0-9]+)/profile$
+```json
+//JSON Escaped Regex URL
+"url": "^https://api\\.example\\.com/users/(?P<user_id>[0-9]+)/profile$"
 ```
 :::tip Matches
 This pattern will match URLs with a numeric user ID in the path. It will match:
@@ -159,8 +190,9 @@ This pattern is perfect for RESTful APIs where you need to extract a numeric ID 
 
 
 #### Optional Path Component
-```regex
-^https://api\.example\.com/api/users(?:/(?P<user_id>[0-9]+))?$
+```json
+//JSON Escaped Regex URL
+"url": "^https://api\\.example\\.com/api/users(?:/(?P<user_id>[0-9]+))?$"
 ```
 :::tip Matches
 This pattern will match URLs with an optional user ID. It will match:
@@ -189,8 +221,9 @@ This pattern is useful when you have endpoints that can work both with and witho
 
 
 #### Multiple Query Parameters
-```regex
-^https://api\.example\.com/search\?(?=.*q=(?P<query>[^&]+))(?=.*page=(?P<page>[0-9]+)).*$
+```json
+//JSON Escaped Regex URL
+"url": "^https://api\\.example\\.com/search\\?(?=.*q=(?P<query>[^&]+))(?=.*page=(?P<page>[0-9]+)).*$"
 ```
 :::tip Matches
 This pattern will match URLs with specific query parameters in any order. It will match:
@@ -220,8 +253,9 @@ This pattern is ideal for search endpoints where parameters can appear in any or
 
 
 #### Subdomain Matching
-```regex
-^https://[\w-]+\.example\.com/api/v1/users/(?P<user_id>[0-9]+)$
+```json
+//JSON Escaped Regex URL
+"url": "^https://[\\w-]+\\.example\\.com/api/v1/users/(?P<user_id>[0-9]+)$"
 ```
 :::tip Matches
 This pattern will match URLs with any subdomain. It will match:
@@ -251,8 +285,9 @@ This pattern is perfect for environments like staging, dev, or production APIs.
 
 
 #### Flexible User Path Matching
-```regex
-^https?:\/\/[^\/]+(?:.*?\/users(?:\/(?P<user_id>[^\/]+))?(?:\/.*)?)?$
+```json
+//JSON Escaped Regex URL
+"url": "^https?:\\/\\/[^\\/]+(?:.*?\\/users(?:\\/(?P<user_id>[^\\/]+))?(?:\\/.*)?)?$"
 ```
 :::tip Matches
 This pattern is useful for matching any URL that contains a user ID, regardless of the exact path structure. It will match URLs like:
@@ -284,8 +319,9 @@ This pattern is extremely flexible, matching any URL structure that contains a u
 
 
 #### Protocol-Agnostic Matching
-```regex
-^https?:\/\/api\.example\.com\/users\/(?P<user_id>[0-9]+)\/profile$
+```json
+//JSON Escaped Regex URL
+"url": "^https?:\\/\\/api\\.example\\.com\\/users\\/(?P<user_id>[0-9]+)\\/profile$"
 ```
 :::tip Matches
 This pattern will match both HTTP and HTTPS URLs. It will match:
@@ -314,8 +350,9 @@ This pattern is useful when your API needs to support both secure and non-secure
 
 
 #### Domain-Agnostic Matching
-```regex
-^https:\/\/[^\/]+\/api\/v1\/users\/(?P<user_id>[0-9]+)\/profile$
+```json
+//JSON Escaped Regex URL
+"url": "^https:\\/\\/[^\\/]+\\/api\\/v1\\/users\\/(?P<user_id>[0-9]+)\\/profile$"
 ```
 :::tip Matches
 This pattern will match any domain name. It will match:


### PR DESCRIPTION
Found some confusing info on the doc. 

-- Added section so the user knows how to test the mapping feature for regex

-- clarified the example regex to note that it is JSON escaped so that it works.