### PR TITLE
add docs for Prisma ORM (Permit-Prisma Extension)

### DIFF
--- a/docs/sdk/permit-prisma-extension.mdx
+++ b/docs/sdk/permit-prisma-extension.mdx
@@ -1,0 +1,192 @@
+---
+title: Permit-Prisma Client Extension
+sidebar_label: Prisma ORM
+description: Integrate Permit.io fine-grained permissions directly into Prisma Client queries using the @permitio/permit-prisma extension.
+---
+
+# Permit-Prisma Extension
+
+## Overview
+
+The Permit-Prisma extension integrates Permit.io's fine-grained authorization directly into your Prisma ORM queries, ensuring that every database operation respects your centralized permission policies. This integration works at the data layer, automatically enforcing access controls for create, read, update, and delete operations across your application.
+
+:::tip TL;DR
+- Seamlessly integrate Permit.io authorization into your Prisma database operations
+- Support for all authorization models: RBAC, ABAC, and ReBAC
+- Automatic permission checks on database operations
+- Data filtering based on user permissions
+- Resource instance synchronization with Permit.io
+:::
+
+## Key Capabilities
+
+The Permit-Prisma extension provides three core capabilities:
+
+1. **Direct Permission Checks**: Automatically verifies if users are authorized to perform specific actions on resources before executing database operations.
+
+2. **Permission Filtering**: Restricts database queries so users only see data they're authorized to access, implementing true row-level security.
+
+3. **Resource Synchronization**: Keeps your Permit.io policy engine in sync with your database by automatically ingesting resource instances and their relationships.
+
+## Installation
+
+Install the package (alongside the Prisma client package) from npm:
+
+```bash
+npm install @permitio/permit-prisma @prisma/client
+```
+## Prerequisites
+
+Before using the extension, ensure you have:
+
+- A [Permit.io account](https://app.permit.io)
+- Permit's environment API key from your project settings
+- A Policy Decision Point (PDP) - either Permit's hosted cloud PDP or a local PDP container (Use locally deployed PDP for ABAC and ReBAC policies)
+- Resources, actions, roles and policies defined in Permit.io's dashboard or via the API
+
+## Basic Setup
+
+```ts
+import { PrismaClient } from "@prisma/client";
+import { createPermitClientExtension } from "@permitio/permit-prisma";
+
+const prisma = new PrismaClient().$extends(
+  createPermitClientExtension({
+    permitConfig: {
+      token: "<YOUR_PERMIT_API_KEY>", // Permit API Key
+      pdp: "http://localhost:7766",   // PDP address
+    },
+    accessControlModel: "RBAC",       // 'RBAC', 'ABAC', or 'ReBAC'
+    enableAutomaticChecks: true,      // Enable automatic permission enforcement
+  })
+);
+```
+## Permission Enforcement
+
+The Permit-Prisma extension implements fine-grained authorization checks on all Prisma operations. Here's how it works:
+
+### Permission Check Flow
+
+When `enableAutomaticChecks` is enabled, the extension:
+
+1. Intercepts all Prisma operations (create, read, update, delete)
+2. Maps the operation to a corresponding Permit.io action
+3. Checks if the current user has permission for that action on the resource
+4. Allows the operation to proceed if authorized, or throws a PermitError if denied
+
+```ts
+// Set the active user for permission checks
+prisma.$permit.setUser("john@example.com");
+
+// This will be checked against Permit.io policies automatically
+try {
+  const document = await prisma.document.create({
+    data: {
+      title: "New Document",
+      content: "Document content",
+    }
+  });
+  console.log("Document created successfully");
+} catch (error) {
+  if (error instanceof PermitError) {
+    console.error("Permission denied");
+  }
+}
+
+## Support for All Access Control Models
+
+The extension supports all three Permit.io access control models:
+
+### Role-Based Access Control (RBAC)
+
+For RBAC, the extension performs simple checks based on the user's roles:
+
+```ts
+// Configure for RBAC
+const prisma = new PrismaClient().$extends(
+  createPermitClientExtension({
+    permitConfig: { token: "YOUR_API_KEY", pdp: "http://localhost:7766" },
+    accessControlModel: "rbac",
+    enableAutomaticChecks: true
+  })
+);
+
+// Simple role-based check
+prisma.$permit.setUser("admin@example.com");
+const documents = await prisma.document.findMany(); // Will succeed if admin role has
+```
+
+### Attribute-Based Access Control (ABAC)
+
+For ABAC, the extension includes attribute information in permission checks:
+
+```ts
+// Configure for ABAC
+const prisma = new PrismaClient().$extends(
+  createPermitClientExtension({
+    permitConfig: { token: "YOUR_API_KEY", pdp: "http://localhost:7766" },
+    accessControlModel: "abac",
+    enableAutomaticChecks: true,
+  })
+);
+
+// Set user with attributes
+prisma.$permit.setUser({
+  key: "doctor@hospital.com",
+  attributes: { department: "cardiology" }
+});
+
+// Will succeed only if user department matches record department based on policy
+const records = await prisma.medicalRecord.findMany({
+  where: { department: "cardiology" }
+});
+```
+### Relationship-Based Access Control (ReBAC)
+
+For ReBAC, the extension performs instance-level permission checks:
+
+```ts
+// Configure for ReBAC
+const prisma = new PrismaClient().$extends(
+  createPermitClientExtension({
+    permitConfig: { token: "YOUR_API_KEY", pdp: "http://localhost:7766" },
+    accessControlModel: "rebac",
+    enableAutomaticChecks: true,
+  })
+);
+
+// Set user for instance-level permissions
+prisma.$permit.setUser("owner@example.com");
+
+// Will only succeed if the user has permission on this specific file instance
+const file = await prisma.file.findUnique({
+  where: { id: "file-123" }
+});
+```
+
+## Manual Permission Checks
+
+For more control, you can also perform manual permission checks:
+
+```ts
+// Check permission manually
+const canUpdateDocument = await prisma.$permit.check(
+  "john@example.com", // user
+  "update",           // action
+  "document"          // resource
+);
+
+if (canUpdateDocument) {
+  await prisma.document.update({
+    where: { id: "doc-123" },
+    data: { title: "Updated Title" }
+  });
+}
+
+// Or enforce check (throws if denied)
+await prisma.$permit.enforceCheck(
+  "john@example.com",
+  "delete",
+  { type: "document", key: "doc-123" }
+);
+await prisma.document.delete({ where: { id: "doc-123" } });

--- a/sidebars.js
+++ b/sidebars.js
@@ -567,6 +567,11 @@ const sidebars = {
           id: "sdk/sdks-overview",
           label: "SDK Feature Parity",
         },
+        {
+          type: "doc",
+          id: "sdk/permit-prisma-extension",
+          label: "Prisma ORM",
+        }
       ],
     },
     {


### PR DESCRIPTION
# Add documentation for Permit-Prisma Extension

This PR adds comprehensive documentation for the Permit-Prisma client extension, including:

- Overview of the extension's capabilities
- Setup and configuration instructions
- Examples for different access control models (RBAC, ABAC, ReBAC)
- Explanation of permission check functionality
- Code examples for various use cases

The documentation follows Permit.io's style guidelines and provides clear, concise information for developers integrating fine-grained authorization with Prisma ORM.