### PR TITLE
Add health check configuration options for PDP and Horizon services

### DIFF
--- a/docs/concepts/pdp/configuration.mdx
+++ b/docs/concepts/pdp/configuration.mdx
@@ -58,6 +58,12 @@ Default: `7766`
 
 The port the PDP server will listen on.
 
+#### PDP_HEALTHCHECK_TIMEOUT
+
+Default: `3`
+
+Timeout in seconds for health checks. This controls how long the PDP will wait for health check responses before timing out.
+
 #### PDP_USE_NEW_AUTHORIZED_USERS
 
 Default: `false`
@@ -392,6 +398,54 @@ Niceness values range from -20 (highest priority) to 19 (lowest priority), where
 
 This setting helps manage CPU resource allocation, particularly the interaction between the Horizon service and the OPA process. 
 A higher value (e.g., 10, the default) makes Horizon 'nicer', yielding CPU more readily to other processes like OPA. 
+
+_Added in PDP v0.9.0_
+
+#### PDP_HORIZON_HEALTH_CHECK_TIMEOUT
+
+Default: `1`
+
+Timeout in seconds for individual health check requests to the Horizon service. If a health check takes longer than this timeout, it will be considered failed.
+
+_Added in PDP v0.9.0_
+
+#### PDP_HORIZON_HEALTH_CHECK_INTERVAL
+
+Default: `5`
+
+Interval in seconds between consecutive health checks of the Horizon service. The PDP will continuously monitor the Horizon service at this interval.
+
+_Added in PDP v0.9.0_
+
+#### PDP_HORIZON_HEALTH_CHECK_FAILURE_THRESHOLD
+
+Default: `12`
+
+Number of consecutive health check failures before the PDP will attempt to restart the Horizon service. This helps ensure service reliability by automatically recovering from failures.
+
+_Added in PDP v0.9.0_
+
+#### PDP_HORIZON_STARTUP_DELAY
+
+Default: `5`
+
+Initial delay in seconds before the PDP begins health checking the Horizon service after startup. This allows the Horizon service time to fully initialize before monitoring begins.
+
+_Added in PDP v0.9.0_
+
+#### PDP_HORIZON_RESTART_INTERVAL
+
+Default: `1`
+
+Interval in seconds between service restart attempts when the Horizon service needs to be restarted due to health check failures.
+
+_Added in PDP v0.9.0_
+
+#### PDP_HORIZON_TERMINATION_TIMEOUT
+
+Default: `30`
+
+Timeout in seconds to wait for the Horizon service to gracefully terminate during shutdown or restart operations. After this timeout, the service will be forcefully terminated.
 
 _Added in PDP v0.9.0_
 


### PR DESCRIPTION
- Introduced new configuration options: PDP_HEALTHCHECK_TIMEOUT, PDP_HORIZON_HEALTH_CHECK_TIMEOUT, PDP_HORIZON_HEALTH_CHECK_INTERVAL, PDP_HORIZON_HEALTH_CHECK_FAILURE_THRESHOLD, PDP_HORIZON_STARTUP_DELAY, PDP_HORIZON_RESTART_INTERVAL, and PDP_HORIZON_TERMINATION_TIMEOUT.
- Each option includes a default value and a description of its purpose.
- All options are added in PDP v0.9.0.