### PR TITLE
Add PDP_CONTROL_PLANE_TIMEOUT configuration option to documentation

### DIFF
--- a/docs/concepts/pdp/configuration.mdx
+++ b/docs/concepts/pdp/configuration.mdx
@@ -35,6 +35,13 @@ Default: `https://api.permit.io`
 
 The URL of the Permit.io control plane.
 
+#### PDP_CONTROL_PLANE_TIMEOUT
+
+Default: `75`
+
+Timeout in seconds for control plane requests. 
+This includes proxied requests for the [Consistent Updates](/how-to/manage-data/local-facts-uploader) APIs.
+
 #### PDP_DEBUG
 
 Default: `None`


### PR DESCRIPTION
Included details on the new timeout setting for control plane requests, specifying a default value of 75 seconds. This update enhances the clarity of the configuration options available for the Permit.io control plane.