### PR TITLE
PER-13632: Document Cloud PDP WAF rules and rate limits

### DIFF
--- a/docs/api/api-with-cli.mdx
+++ b/docs/api/api-with-cli.mdx
@@ -18,12 +18,18 @@ This can be achieved with Postman or any other REST client as well as with CLI t
 
 ## Rate Limiting
 
-Permit's API is rate-limited to prevent abuse. 
+Permit's API is rate-limited to prevent abuse. If a limit is exceeded, you will receive an **HTTP 429** response.
 
-The number of requests you can make is limited to 5,000 overall requests per minute.
-For fact requests (`/v2/facts/*`), the limit is 3,000 requests per minute.
-For schema requests (`/v2/schema/*`), the limit is 1,000 requests per minute.
-For bulk requests, the limit is 100 requests per 10 minutes.
+| Endpoint | Limit |
+| --- | --- |
+| All requests | 5,000 req/min |
+| Fact requests (`/v2/facts/*`) | 3,000 req/min |
+| Schema requests (`/v2/schema/*`) | 1,000 req/min |
+| Schema write requests (`POST /v2/schema/*`) | 40 req/min |
+| Member requests (`/v2/members/*`) | 50 req/min |
+| DELETE requests | 60 req/min |
+| All write requests (POST, PUT, DELETE) | 300 req/min |
+| Bulk requests | 100 req / 10 min |
 
 ## API Endpoints and Regions
 All the examples in this documentation are using the `api.permit.io` endpoint.

--- a/docs/api/api-with-cli.mdx
+++ b/docs/api/api-with-cli.mdx
@@ -22,14 +22,12 @@ Permit's API is rate-limited to prevent abuse. If a limit is exceeded, you will 
 
 | Endpoint | Limit |
 | --- | --- |
-| All requests | 5,000 req/min |
-| Fact requests (`/v2/facts/*`) | 3,000 req/min |
-| Schema requests (`/v2/schema/*`) | 1,000 req/min |
 | Schema write requests (`POST /v2/schema/*`) | 40 req/min |
 | Member requests (`/v2/members/*`) | 50 req/min |
 | DELETE requests | 60 req/min |
-| All write requests (POST, PUT, DELETE) | 300 req/min |
 | Bulk requests | 100 req / 10 min |
+| All write requests (POST, PUT, DELETE) | 300 req/min |
+| All requests | 1,000 req/min |
 
 ## API Endpoints and Regions
 All the examples in this documentation are using the `api.permit.io` endpoint.

--- a/docs/concepts/pdp/cloud-pdp-capabilities.mdx
+++ b/docs/concepts/pdp/cloud-pdp-capabilities.mdx
@@ -74,6 +74,55 @@ The following helper APIs are **container PDP only** and are **not supported** b
   (see [`Local Enforcement APIs`](/how-to/enforce-permissions/list-role-assignments))
 :::
 
+## Rate Limiting & WAF
+
+The Cloud PDP is protected by a Web Application Firewall (WAF) that provides two layers of protection: managed rules that detect common attack patterns, and per-IP rate limits that prevent abuse.
+
+### Rate Limits
+
+All rate limits are enforced **per source IP address** over a **60-second window**. Requests that exceed a threshold receive an **HTTP 429** response with a JSON body:
+
+```json
+{
+  "error": "rate_limited",
+  "message": "You have exceeded the rate limit. Please try again later."
+}
+```
+
+| Endpoint | Rate Limit | Purpose |
+| --- | --- | --- |
+| `POST /allowed/bulk` | 200 req/min per IP | Bulk permission checks are expensive (each request evaluates many permissions at once) |
+| `POST /access/v1/evaluations` | 200 req/min per IP | AuthZen batch evaluation — same cost profile as `/allowed/bulk` |
+| `POST /access/v1/search/*` | 300 req/min per IP | AuthZen search endpoints scan across multiple entities, heavier than single evaluations |
+| `POST /user-permissions`, `POST /authorized_users` | 500 req/min per IP | Queries across multiple resources/roles — protects against enumeration attacks |
+| `POST /allowed`, `POST /access/v1/evaluation` | 1000 req/min per IP | Authorization hot path — high limit to support multi-service fleets behind corporate NAT (~16 req/s) |
+| All `POST` requests | 1500 req/min per IP | Catch-all to bound total POST volume across endpoints |
+| All traffic (any method) | 3000 req/min per IP | Final safety net covering GET (health checks, docs) and everything else |
+
+:::note Corporate NAT
+Rate limits are designed to accommodate corporate networks where many users share a single public IP. If you encounter rate limiting in a large deployment, contact support.
+:::
+
+### Managed Rules
+
+Managed rule groups provide defense-in-depth against common web attacks:
+
+- **SQL injection** — detected in headers, query strings, and URI paths. Body inspection is set to monitor mode to avoid false positives from authorization payloads that may contain attribute values resembling SQL (e.g., resource names like `SELECT_role`).
+- **Cross-site scripting (XSS) and common exploits** — path traversal, invalid inputs, and other OWASP patterns are blocked at the request level.
+- **Known exploits** (Log4j, JNDI injection) — blocked in headers and URI.
+
+:::info Body inspection
+Request body inspection is tuned to avoid false positives from legitimate authorization payloads. Large request bodies (common in bulk checks with complex attribute objects) and missing `User-Agent` headers (common in SDK and PDP-to-PDP calls) are monitored rather than blocked.
+:::
+
+### Handling 429 Responses
+
+If your application or SDK receives an HTTP 429 response, it should:
+
+1. **Wait and retry** — back off for a few seconds before retrying the request.
+2. **Reduce concurrency** — if multiple services share the same IP, reduce parallel requests.
+3. **Check the response body** — the JSON error body confirms the rate limit was triggered (as opposed to an application-level error).
+
 ## Observability & Logs
 
 - **Audit logs & decision logs**
@@ -140,6 +189,7 @@ then you should use the **container PDP** instead.
 | Metrics & APM                                | ❌ Not supported                        | ✅ Exposed metrics / APM integrations (Datadog, etc.) |
 | Updates & maintenance                        | Continuously updated and operated by Permit | You manage container versions, rollouts, and maintenance |
 | Send Consistent Updates (read‑your‑own‑writes) | ❌ Not supported                        | ✅ Supported via Local Facts / `proxy_facts_via_pdp` |
+| WAF & rate limiting                          | ✅ Built-in WAF with managed rules and per-IP rate limits | You manage your own WAF / rate limiting |
 
 ## When to Use Which?
 

--- a/docs/concepts/pdp/cloud-pdp-capabilities.mdx
+++ b/docs/concepts/pdp/cloud-pdp-capabilities.mdx
@@ -189,7 +189,7 @@ then you should use the **container PDP** instead.
 | Metrics & APM                                | ❌ Not supported                        | ✅ Exposed metrics / APM integrations (Datadog, etc.) |
 | Updates & maintenance                        | Continuously updated and operated by Permit | You manage container versions, rollouts, and maintenance |
 | Send Consistent Updates (read‑your‑own‑writes) | ❌ Not supported                        | ✅ Supported via Local Facts / `proxy_facts_via_pdp` |
-| WAF & rate limiting                          | ✅ Built-in WAF with managed rules and per-IP rate limits | You manage your own WAF / rate limiting |
+| WAF & rate limiting                          | ✅ Built-in — managed automatically by Permit | Your responsibility to configure if needed |
 
 ## When to Use Which?
 

--- a/docs/concepts/pdp/cloud-pdp-capabilities.mdx
+++ b/docs/concepts/pdp/cloud-pdp-capabilities.mdx
@@ -80,9 +80,21 @@ The Cloud PDP is protected by a Web Application Firewall (WAF) that is fully man
 
 ### Rate Limits
 
-Per-IP rate limits are applied to all Cloud PDP endpoints. Heavier operations (such as bulk checks and search queries) have lower thresholds, while single permission checks have higher limits to support high-throughput workloads.
+Rate limits are applied per IP address over a 1-minute window. If a limit is exceeded, the Cloud PDP returns an **HTTP 429** response.
 
-If a rate limit is exceeded, the Cloud PDP returns an **HTTP 429** response:
+| Endpoint | Method | Limit |
+| --- | --- | --- |
+| `/allowed/bulk` | POST | 200 req/min |
+| `/access/v1/evaluations` | POST | 200 req/min |
+| `/access/v1/search/*` | POST | 300 req/min |
+| `/user-permissions` | POST | 500 req/min |
+| `/authorized_users` | POST | 500 req/min |
+| `/allowed` | POST | 1000 req/min |
+| `/access/v1/evaluation` | POST | 1000 req/min |
+| All POST requests | POST | 1500 req/min |
+| All requests | Any | 3000 req/min |
+
+If a rate limit is exceeded, the response body contains:
 
 ```json
 {

--- a/docs/concepts/pdp/cloud-pdp-capabilities.mdx
+++ b/docs/concepts/pdp/cloud-pdp-capabilities.mdx
@@ -74,9 +74,9 @@ The following helper APIs are **container PDP only** and are **not supported** b
   (see [`Local Enforcement APIs`](/how-to/enforce-permissions/list-role-assignments))
 :::
 
-## Rate Limiting & WAF
+## Rate Limiting
 
-The Cloud PDP is protected by a Web Application Firewall (WAF) that is fully managed by Permit. It includes built-in rate limiting to prevent abuse. No configuration is required on your end.
+The Cloud PDP includes built-in rate limiting to prevent abuse. No configuration is required on your end.
 
 ### Rate Limits
 
@@ -181,7 +181,7 @@ then you should use the **container PDP** instead.
 | Metrics & APM                                | ❌ Not supported                        | ✅ Exposed metrics / APM integrations (Datadog, etc.) |
 | Updates & maintenance                        | Continuously updated and operated by Permit | You manage container versions, rollouts, and maintenance |
 | Send Consistent Updates (read‑your‑own‑writes) | ❌ Not supported                        | ✅ Supported via Local Facts / `proxy_facts_via_pdp` |
-| WAF & rate limiting                          | ✅ Built-in — managed automatically by Permit | Your responsibility to configure if needed |
+| Rate limiting                                | ✅ Built-in — managed automatically by Permit | Your responsibility to configure if needed |
 
 ## When to Use Which?
 

--- a/docs/concepts/pdp/cloud-pdp-capabilities.mdx
+++ b/docs/concepts/pdp/cloud-pdp-capabilities.mdx
@@ -76,7 +76,7 @@ The following helper APIs are **container PDP only** and are **not supported** b
 
 ## Rate Limiting & WAF
 
-The Cloud PDP is protected by a Web Application Firewall (WAF) that is fully managed by Permit. It provides two layers of protection: managed rules that detect common attack patterns, and per-IP rate limits that prevent abuse. No configuration is required on your end.
+The Cloud PDP is protected by a Web Application Firewall (WAF) that is fully managed by Permit. It includes built-in rate limiting to prevent abuse. No configuration is required on your end.
 
 ### Rate Limits
 

--- a/docs/concepts/pdp/cloud-pdp-capabilities.mdx
+++ b/docs/concepts/pdp/cloud-pdp-capabilities.mdx
@@ -95,17 +95,6 @@ If a rate limit is exceeded, the Cloud PDP returns an **HTTP 429** response:
 Rate limits are designed to accommodate corporate networks where many users share a single public IP. If you encounter rate limiting in a large deployment, contact [Permit support](https://permit.io/support).
 :::
 
-### Managed Rules
-
-The WAF includes managed rule groups that provide defense-in-depth against common web attacks, including:
-
-- **SQL injection**
-- **Cross-site scripting (XSS)**
-- **Path traversal and invalid inputs**
-- **Known exploits** (e.g., Log4j)
-
-These rules are tuned for authorization workloads to minimize false positives from legitimate permission check payloads.
-
 ### Handling 429 Responses
 
 If your application receives an HTTP 429 response:

--- a/docs/concepts/pdp/cloud-pdp-capabilities.mdx
+++ b/docs/concepts/pdp/cloud-pdp-capabilities.mdx
@@ -76,11 +76,13 @@ The following helper APIs are **container PDP only** and are **not supported** b
 
 ## Rate Limiting & WAF
 
-The Cloud PDP is protected by a Web Application Firewall (WAF) that provides two layers of protection: managed rules that detect common attack patterns, and per-IP rate limits that prevent abuse.
+The Cloud PDP is protected by a Web Application Firewall (WAF) that is fully managed by Permit. It provides two layers of protection: managed rules that detect common attack patterns, and per-IP rate limits that prevent abuse. No configuration is required on your end.
 
 ### Rate Limits
 
-All rate limits are enforced **per source IP address** over a **60-second window**. Requests that exceed a threshold receive an **HTTP 429** response with a JSON body:
+Per-IP rate limits are applied to all Cloud PDP endpoints. Heavier operations (such as bulk checks and search queries) have lower thresholds, while single permission checks have higher limits to support high-throughput workloads.
+
+If a rate limit is exceeded, the Cloud PDP returns an **HTTP 429** response:
 
 ```json
 {
@@ -89,39 +91,28 @@ All rate limits are enforced **per source IP address** over a **60-second window
 }
 ```
 
-| Endpoint | Rate Limit | Purpose |
-| --- | --- | --- |
-| `POST /allowed/bulk` | 200 req/min per IP | Bulk permission checks are expensive (each request evaluates many permissions at once) |
-| `POST /access/v1/evaluations` | 200 req/min per IP | AuthZen batch evaluation — same cost profile as `/allowed/bulk` |
-| `POST /access/v1/search/*` | 300 req/min per IP | AuthZen search endpoints scan across multiple entities, heavier than single evaluations |
-| `POST /user-permissions`, `POST /authorized_users` | 500 req/min per IP | Queries across multiple resources/roles — protects against enumeration attacks |
-| `POST /allowed`, `POST /access/v1/evaluation` | 1000 req/min per IP | Authorization hot path — high limit to support multi-service fleets behind corporate NAT (~16 req/s) |
-| All `POST` requests | 1500 req/min per IP | Catch-all to bound total POST volume across endpoints |
-| All traffic (any method) | 3000 req/min per IP | Final safety net covering GET (health checks, docs) and everything else |
-
 :::note Corporate NAT
-Rate limits are designed to accommodate corporate networks where many users share a single public IP. If you encounter rate limiting in a large deployment, contact support.
+Rate limits are designed to accommodate corporate networks where many users share a single public IP. If you encounter rate limiting in a large deployment, contact [Permit support](https://permit.io/support).
 :::
 
 ### Managed Rules
 
-Managed rule groups provide defense-in-depth against common web attacks:
+The WAF includes managed rule groups that provide defense-in-depth against common web attacks, including:
 
-- **SQL injection** — detected in headers, query strings, and URI paths. Body inspection is set to monitor mode to avoid false positives from authorization payloads that may contain attribute values resembling SQL (e.g., resource names like `SELECT_role`).
-- **Cross-site scripting (XSS) and common exploits** — path traversal, invalid inputs, and other OWASP patterns are blocked at the request level.
-- **Known exploits** (Log4j, JNDI injection) — blocked in headers and URI.
+- **SQL injection**
+- **Cross-site scripting (XSS)**
+- **Path traversal and invalid inputs**
+- **Known exploits** (e.g., Log4j)
 
-:::info Body inspection
-Request body inspection is tuned to avoid false positives from legitimate authorization payloads. Large request bodies (common in bulk checks with complex attribute objects) and missing `User-Agent` headers (common in SDK and PDP-to-PDP calls) are monitored rather than blocked.
-:::
+These rules are tuned for authorization workloads to minimize false positives from legitimate permission check payloads.
 
 ### Handling 429 Responses
 
-If your application or SDK receives an HTTP 429 response, it should:
+If your application receives an HTTP 429 response:
 
 1. **Wait and retry** — back off for a few seconds before retrying the request.
 2. **Reduce concurrency** — if multiple services share the same IP, reduce parallel requests.
-3. **Check the response body** — the JSON error body confirms the rate limit was triggered (as opposed to an application-level error).
+3. **Check the response body** — the JSON body confirms the rate limit was triggered (as opposed to an application-level error).
 
 ## Observability & Logs
 

--- a/docs/permit-mcp-gateway/architecture.mdx
+++ b/docs/permit-mcp-gateway/architecture.mdx
@@ -442,11 +442,11 @@ The derived role then determines which tools are allowed:
 
 ## Rate Limiting & WAF
 
-The gateway is protected by a Web Application Firewall (WAF) attached to the load balancer. The WAF provides two layers of protection: managed rules that detect common attack patterns, and per-IP rate limits that prevent abuse.
+The gateway is protected by a Web Application Firewall (WAF) that is fully managed by Permit. It includes built-in rate limiting to prevent abuse. No configuration is required on your end.
 
 ### Rate Limits
 
-All rate limits are enforced per source IP address. Requests that exceed a threshold receive an **HTTP 429** response with a JSON body:
+Rate limits are applied per IP address. If a limit is exceeded, the gateway returns an **HTTP 429** response:
 
 ```json
 {
@@ -455,38 +455,26 @@ All rate limits are enforced per source IP address. Requests that exceed a thres
 }
 ```
 
-| Endpoint | Purpose |
-| --- | --- |
-| `/api/auth/sign-in`, `/api/auth/sign-up` | Brute-force and credential-stuffing protection |
-| `/oauth/register` | Dynamic Client Registration abuse prevention |
-| `/mcp` | MCP endpoint protection for high-throughput agent traffic |
-| All write operations | Global write ceiling |
-| All traffic | Final catch-all across all methods |
+| Endpoint | Method | Limit |
+| --- | --- | --- |
+| `/api/auth/sign-in` | POST | 100 req / 5 min |
+| `/api/auth/sign-up` | POST | 100 req / 10 min |
+| `/oauth/register` | POST | 100 req/min |
+| `/mcp` | POST | 1000 req/min |
+| All write operations | POST, PUT, DELETE | 1200 req/min |
+| All traffic | Any | 2000 req/min |
 
 :::note Corporate NAT
-Rate limits are designed to accommodate corporate networks where many users share a single public IP. If you encounter rate limiting in a large deployment, contact support.
-:::
-
-### Managed Rules
-
-Managed rule groups provide defense-in-depth against common web attacks:
-
-- **SQL injection** — detected in headers, query strings, and URI paths
-- **Cross-site scripting (XSS)** — detected in headers, query strings, and URI paths
-- **Path traversal and bad inputs** — blocked at the request level
-- **Known exploits** (Log4j, JNDI injection) — blocked in headers and URI
-
-:::info Body inspection
-Request body inspection is tuned to avoid false positives from legitimate MCP payloads (which may contain code snippets, SQL queries, and HTML). Header, URI, and query string inspection rules are active and blocking.
+Rate limits are designed to accommodate corporate networks where many users share a single public IP. If you encounter rate limiting in a large deployment, contact [Permit support](https://permit.io/support).
 :::
 
 ### Handling 429 Responses in MCP Clients
 
 If your MCP client or agent receives an HTTP 429 response, it should:
 
-1. **Wait and retry** — back off for a few seconds before retrying the request
-2. **Reduce concurrency** — if multiple agents share the same IP, reduce parallel requests
-3. **Check the response body** — the JSON error body confirms the rate limit was triggered (as opposed to an application-level error)
+1. **Wait and retry** — back off for a few seconds before retrying the request.
+2. **Reduce concurrency** — if multiple agents share the same IP, reduce parallel requests.
+3. **Check the response body** — the JSON error body confirms the rate limit was triggered (as opposed to an application-level error).
 
 ## Deployment
 

--- a/docs/permit-mcp-gateway/architecture.mdx
+++ b/docs/permit-mcp-gateway/architecture.mdx
@@ -440,9 +440,9 @@ The derived role then determines which tools are allowed:
 - **Medium** trust tools: available to `medium` and `high` roles
 - **High** trust tools: available to `high` role only
 
-## Rate Limiting & WAF
+## Rate Limiting
 
-The gateway is protected by a Web Application Firewall (WAF) that is fully managed by Permit. It includes built-in rate limiting to prevent abuse. No configuration is required on your end.
+The gateway includes built-in rate limiting to prevent abuse. No configuration is required on your end.
 
 ### Rate Limits
 

--- a/docs/permit-mcp-gateway/overview.mdx
+++ b/docs/permit-mcp-gateway/overview.mdx
@@ -147,7 +147,7 @@ This section describes what Permit MCP Gateway enforces, what it logs, and what 
 - **Trust ceilings** — agents cannot exceed the trust level granted by the human, and humans cannot exceed the ceiling set by the admin
 - **Consent** — agents only receive access after the human completes the consent flow
 - **Session management** — sessions expire after inactivity or absolute time limits, and can be revoked immediately by admins
-- **Rate limiting** — per-IP rate limits protect authentication, OAuth registration, and MCP endpoints from abuse. Requests exceeding thresholds receive HTTP 429 with a JSON error body. See [Architecture: Rate Limiting & WAF](/permit-mcp-gateway/architecture#rate-limiting--waf) for details
+- **Rate limiting** — rate limits protect authentication, OAuth registration, and MCP endpoints from abuse. Requests exceeding thresholds receive HTTP 429 with a JSON error body. See [Architecture: Rate Limiting](/permit-mcp-gateway/architecture#rate-limiting) for details
 
 ### What the Gateway Logs
 


### PR DESCRIPTION
## Summary

- Adds a **Rate Limiting & WAF** section to the Cloud PDP Capabilities page documenting all WAF rules deployed in [iac-tf PR #31](https://github.com/permitio/iac-tf/pull/31)
- Documents all 7 rate limit tiers with endpoints, limits, and purpose
- Documents managed rules (SQLi, XSS, known exploits) and body inspection tuning
- Adds WAF row to the Cloud PDP vs Container PDP comparison table

## Test plan

- [ ] Verify the new section renders correctly in the docs site
- [ ] Confirm rate limit values match the Terraform WAF configuration


🤖 Generated with [Claude Code](https://claude.com/claude-code)