### PR TITLE
Add Enterprise Deployment docs with on-prem and air-gapped upsell

### DIFF
--- a/docs/permit-mcp-gateway/advanced-features.mdx
+++ b/docs/permit-mcp-gateway/advanced-features.mdx
@@ -138,3 +138,5 @@ The following capabilities have been referenced in marketing materials but are n
 ---
 
 **Interested in Enterprise features?** [Schedule a demo](https://calendly.com/permit-io/demo) or reach out at [support@permit.io](mailto:support@permit.io). You can also find us on [Slack](https://io.permit.io/slack).
+
+**Need the gateway in your own infrastructure?** See [Enterprise Deployment](/permit-mcp-gateway/enterprise-deployment) for customer-controlled deployment options, including local PDP, private MCP servers, and data residency compliance.

--- a/docs/permit-mcp-gateway/architecture.mdx
+++ b/docs/permit-mcp-gateway/architecture.mdx
@@ -482,6 +482,8 @@ Permit MCP Gateway is available as a **hosted gateway** at `*.agent.security`. E
 
 Point your MCP clients to `https://<host>.agent.security/mcp` and the gateway handles the rest — authentication, authorization, and audit logging are all built in.
 
+For organizations that need the gateway inside their own network — for data residency, private MCP servers, or local PDP authorization — see [Enterprise Deployment](/permit-mcp-gateway/enterprise-deployment).
+
 ## Key Advantages
 
 * **Single enforcement point** for authentication, authorization, consent, and audit

--- a/docs/permit-mcp-gateway/enterprise-deployment.mdx
+++ b/docs/permit-mcp-gateway/enterprise-deployment.mdx
@@ -10,7 +10,7 @@ sidebar_position: 10
 For organizations that need MCP gateway enforcement **within their own network boundary**, Permit offers two enterprise deployment models — from running the gateway and PDP locally while using Permit.io as the cloud control plane, to a **fully on-premises deployment** where the entire stack — including the control plane — runs in your environment with no external dependencies.
 
 :::info Getting Started
-Enterprise deployment is available on **Enterprise plans**. The [hosted gateway](/permit-mcp-gateway/overview#hosted-gateway-saas) is the recommended starting point for evaluation — you can migrate to customer-controlled deployment at any time without losing policies, users, or audit history.
+Enterprise deployment is available on **Enterprise plans**. The [hosted gateway](/permit-mcp-gateway/overview#hosted-gateway-saas) is the recommended starting point for evaluation — you can migrate to customer-controlled deployment at any time. Contact your Permit team for migration support.
 :::
 
 ---
@@ -21,9 +21,11 @@ Enterprise deployment is available on **Enterprise plans**. The [hosted gateway]
 
 In the hosted deployment, MCP traffic — including tool call parameters and upstream server responses — flows through Permit's managed infrastructure. For many organizations this is acceptable, but some requirements demand more:
 
-- **Regulated industries** — healthcare (HIPAA), financial services (SOX, PCI-DSS), and government (FedRAMP) environments where data must not leave approved network boundaries
+- **Regulated industries** — healthcare, financial services, and government environments where data must not leave approved network boundaries
 - **Data residency laws** — GDPR, data sovereignty regulations, or contractual obligations that restrict where data can be processed
 - **Internal policy** — organizations with blanket requirements that production traffic stays within corporate infrastructure
+
+These deployment models support requirements common in regulated environments. Permit does not claim certification under specific compliance frameworks — consult your compliance team to evaluate fit.
 
 With customer-controlled deployment, **MCP traffic never leaves your network**. The gateway runs inside your VPC or on-premises data center, and tool calls are proxied directly to upstream MCP servers without traversing external infrastructure.
 
@@ -68,13 +70,13 @@ Permit MCP Gateway supports three deployment models. Choose based on your compli
 
 ### What Stays the Same Across All Models
 
-All deployment models use the **same gateway codebase, same policy model, and same authorization logic**. The differences are purely about where components run and where traffic flows:
+All deployment models use the **same gateway software, same policy engine, and same authorization logic**. The differences are purely about where components run and where traffic flows:
 
 - Same ReBAC policy model with trust levels, consent, and the `min()` ceiling logic
 - Same MCP client configuration — users just point to your internal gateway URL instead of `*.agent.security`
 - Same admin dashboard experience for gateway management
 - Same policy inspection and audit log capabilities
-- Policies, users, and audit history can be migrated seamlessly between deployment models
+- Policies and users can be migrated between deployment models — contact your Permit team for migration support
 
 ---
 
@@ -97,7 +99,7 @@ The fully on-premises package includes everything needed to run the complete Per
 
 The fully on-premises deployment is designed to operate in **air-gapped environments** with no internet connectivity:
 
-- **No outbound connections** — the gateway, PDP, control plane, and all supporting services run entirely within your network boundary. The system is designed to operate without outbound connections — there are no required phone-home, telemetry, or license check mechanisms.
+- **No outbound connections** — the gateway, PDP, control plane, and all supporting services run entirely within your network boundary. The system is designed to operate without required outbound connections. Contact your Permit team for the complete network dependency manifest for your deployment.
 - **Offline policy management** — policies are created, modified, and evaluated locally. Changes propagate from the on-premises control plane to the local PDP without any external dependency.
 - **Self-contained updates** — software updates are delivered as versioned artifacts (container images, binaries) that can be transferred into the air-gapped environment via your existing secure media processes.
 - **Local audit storage** — all audit logs, consent records, and session data are stored within your infrastructure. No data is transmitted externally.
@@ -108,7 +110,7 @@ This deployment model is designed for environments where external connectivity i
 
 - **Defense and intelligence** — classified environments where systems must operate within secure enclaves with no internet access
 - **Critical infrastructure** — energy, utilities, and industrial control environments with strict network isolation requirements
-- **Government and public sector** — agencies subject to FedRAMP High, ITAR, or similar frameworks with strict infrastructure control requirements
+- **Government and public sector** — agencies subject to strict infrastructure control requirements where all components must run within approved boundaries
 - **Healthcare with strict data isolation** — environments where even policy metadata must remain within the compliance boundary
 - **Financial institutions with zero-trust mandates** — organizations that require every component — including policy management — to run within their security perimeter
 
@@ -138,10 +140,10 @@ Set custom consent windows that automatically expire. Grant a contractor's agent
 
 ### Additional Enterprise Controls
 
-- **Agent Verification** — behavioral profiling and identity baseline tracking across sessions
-- **Session Monitoring** — compare declared intent vs. actual tool call patterns, with anomaly surfacing
+- **Agent Verification** *(early access)* — behavioral profiling and identity baseline tracking across sessions
+- **Session Monitoring** *(early access)* — compare declared intent vs. actual tool call patterns, with anomaly surfacing
 - **Permission Receipts** — auditable records of every permission grant for compliance reporting
-- **Intent-Based Access Control** — evaluate agent purpose against policy before execution begins
+- **Intent-Based Access Control** *(roadmap)* — evaluate agent purpose against policy before execution begins
 
 See [Advanced Features](/permit-mcp-gateway/advanced-features) for the full list and maturity status of each capability.
 

--- a/docs/permit-mcp-gateway/enterprise-deployment.mdx
+++ b/docs/permit-mcp-gateway/enterprise-deployment.mdx
@@ -147,40 +147,6 @@ See [Advanced Features](/permit-mcp-gateway/advanced-features) for the full list
 
 ---
 
-## Deployment Scenarios
-
-### Scenario 1: Regulated Environment
-
-A healthcare organization needs AI agents to interact with internal EHR and scheduling systems via MCP. Their compliance policy requires that patient data remain within the corporate network to meet HIPAA safeguard requirements.
-
-**Solution:** Deploy the gateway and local PDP inside the hospital's private cloud. Internal MCP servers (EHR, scheduling) are accessible over the private network. Tool calls containing patient data stay within the compliance boundary. Permit.io serves as the control plane for policy management — only policy metadata (not patient data) is exchanged with the cloud.
-
-### Scenario 2: Financial Services with Private APIs
-
-A bank exposes internal trading and risk systems as MCP servers. These APIs are only accessible within the bank's VPC and cannot be exposed to the internet.
-
-**Solution:** Deploy the gateway inside the VPC with direct network access to internal MCP servers. Agents connect to the gateway over the corporate VPN or internal network. Authorization decisions are made locally, eliminating cross-network latency on high-frequency tool calls.
-
-### Scenario 3: Multi-Region Enterprise
-
-A global enterprise needs gateway instances in multiple regions to comply with data sovereignty requirements and minimize latency.
-
-**Solution:** Deploy independent gateway instances in each region, each with its own local PDP. All instances share the same Permit.io control plane, so policies are consistent. MCP traffic stays within the regional network boundary.
-
-### Scenario 4: Air-Gapped Defense Environment
-
-A defense contractor needs AI agents to interact with classified systems via MCP inside a secure enclave with no internet connectivity.
-
-**Solution:** Deploy the fully on-premises stack — gateway, consent service, PDP, and control plane — entirely within the air-gapped network. Software updates are delivered via secure media transfer. Policies are managed through the on-premises admin dashboard. All audit data stays within the enclave. No component requires or attempts external communication.
-
-### Scenario 5: Hybrid — Hosted + Customer-Controlled
-
-An organization starts with the hosted gateway for non-sensitive workloads (e.g., Jira, Linear, GitHub) and deploys a customer-controlled instance for internal systems containing sensitive data.
-
-**Solution:** Run both deployments simultaneously. Users connect to the hosted gateway for external MCP servers and to the internal gateway for private ones. Both share the same Permit.io organization, providing a unified policy and audit view across deployments.
-
----
-
 ## Migration Path
 
 Organizations typically follow this path:

--- a/docs/permit-mcp-gateway/enterprise-deployment.mdx
+++ b/docs/permit-mcp-gateway/enterprise-deployment.mdx
@@ -147,23 +147,6 @@ See [Advanced Features](/permit-mcp-gateway/advanced-features) for the full list
 
 ---
 
-## Migration Path
-
-Organizations typically follow this path:
-
-1. **Evaluate with hosted** — start with the hosted gateway to validate the product, onboard pilot users, and define trust level policies. No infrastructure investment required.
-2. **Decide on deployment model** — based on your compliance, data residency, and network requirements, determine which model fits:
-   - **Customer-controlled** — gateway and PDP in your environment, Permit.io cloud as control plane
-   - **Fully on-premises** — the entire stack in your environment, including the control plane, with air-gapped support
-3. **Deploy** — Permit provides the gateway artifacts, PDP images, control plane packages (for fully on-prem), and deployment guidance for your target environment (Kubernetes, Docker, VMs). Your existing policies, users, and configurations carry over.
-4. **Operate** — manage policies through the admin dashboard (cloud or on-premises, depending on your model). Monitor audit logs in your preferred location.
-
-:::tip Evaluate First
-We recommend starting with the [hosted gateway](/permit-mcp-gateway/quickstart) even if you know you'll need customer-controlled deployment. This lets you validate fit, define policies, and onboard pilot users without infrastructure setup — then migrate seamlessly when ready.
-:::
-
----
-
 ## Get Started
 
 Enterprise deployment is designed and scoped in collaboration with your team to ensure it meets your specific compliance, network, and operational requirements.

--- a/docs/permit-mcp-gateway/enterprise-deployment.mdx
+++ b/docs/permit-mcp-gateway/enterprise-deployment.mdx
@@ -41,7 +41,7 @@ Running the gateway in your own environment gives you full control over the netw
 
 The hosted gateway evaluates authorization decisions against Permit's cloud PDP. In customer-controlled deployments, you can run a **local PDP** alongside the gateway:
 
-- **Sub-millisecond authorization** — policy decisions evaluated locally, no network round-trip to the cloud
+- **Low-latency authorization** — policy decisions evaluated locally, eliminating network round-trips to the cloud
 - **Resilience** — authorization continues even if internet connectivity to Permit.io is temporarily interrupted
 - **Predictable latency** — no variability from cross-region PDP calls; performance is bounded by local compute
 
@@ -97,7 +97,7 @@ The fully on-premises package includes everything needed to run the complete Per
 
 The fully on-premises deployment is designed to operate in **air-gapped environments** with no internet connectivity:
 
-- **No outbound connections** — the gateway, PDP, control plane, and all supporting services run entirely within your network boundary. There is no phone-home, telemetry, or license check that requires internet access.
+- **No outbound connections** — the gateway, PDP, control plane, and all supporting services run entirely within your network boundary. The system is designed to operate without outbound connections — there are no required phone-home, telemetry, or license check mechanisms.
 - **Offline policy management** — policies are created, modified, and evaluated locally. Changes propagate from the on-premises control plane to the local PDP without any external dependency.
 - **Self-contained updates** — software updates are delivered as versioned artifacts (container images, binaries) that can be transferred into the air-gapped environment via your existing secure media processes.
 - **Local audit storage** — all audit logs, consent records, and session data are stored within your infrastructure. No data is transmitted externally.
@@ -108,7 +108,7 @@ This deployment model is designed for environments where external connectivity i
 
 - **Defense and intelligence** — classified environments where systems must operate within secure enclaves with no internet access
 - **Critical infrastructure** — energy, utilities, and industrial control environments with strict network isolation requirements
-- **Government and public sector** — agencies subject to FedRAMP High, ITAR, or similar frameworks that mandate complete infrastructure control
+- **Government and public sector** — agencies subject to FedRAMP High, ITAR, or similar frameworks with strict infrastructure control requirements
 - **Healthcare with strict data isolation** — environments where even policy metadata must remain within the compliance boundary
 - **Financial institutions with zero-trust mandates** — organizations that require every component — including policy management — to run within their security perimeter
 
@@ -116,7 +116,7 @@ This deployment model is designed for environments where external connectivity i
 
 ## Enterprise Security Controls
 
-Enterprise deployment unlocks additional security capabilities beyond the core gateway features available on all plans.
+Enterprise deployment unlocks additional security capabilities beyond the core gateway features available on all plans. Some features below may be in early access — see the [feature maturity table](/permit-mcp-gateway/advanced-features#feature-maturity-summary) for current status.
 
 ### Agent Interrogation
 
@@ -151,7 +151,7 @@ See [Advanced Features](/permit-mcp-gateway/advanced-features) for the full list
 
 ### Scenario 1: Regulated Environment
 
-A healthcare organization needs AI agents to interact with internal EHR and scheduling systems via MCP, but HIPAA requires that patient data never leaves the corporate network.
+A healthcare organization needs AI agents to interact with internal EHR and scheduling systems via MCP. Their compliance policy requires that patient data remain within the corporate network to meet HIPAA safeguard requirements.
 
 **Solution:** Deploy the gateway and local PDP inside the hospital's private cloud. Internal MCP servers (EHR, scheduling) are accessible over the private network. Tool calls containing patient data stay within the compliance boundary. Permit.io serves as the control plane for policy management — only policy metadata (not patient data) is exchanged with the cloud.
 
@@ -159,7 +159,7 @@ A healthcare organization needs AI agents to interact with internal EHR and sche
 
 A bank exposes internal trading and risk systems as MCP servers. These APIs are only accessible within the bank's VPC and cannot be exposed to the internet.
 
-**Solution:** Deploy the gateway inside the VPC with direct network access to internal MCP servers. Agents connect to the gateway over the corporate VPN or internal network. Authorization decisions are made locally for sub-millisecond latency on high-frequency tool calls.
+**Solution:** Deploy the gateway inside the VPC with direct network access to internal MCP servers. Agents connect to the gateway over the corporate VPN or internal network. Authorization decisions are made locally, eliminating cross-network latency on high-frequency tool calls.
 
 ### Scenario 3: Multi-Region Enterprise
 

--- a/docs/permit-mcp-gateway/enterprise-deployment.mdx
+++ b/docs/permit-mcp-gateway/enterprise-deployment.mdx
@@ -1,0 +1,209 @@
+---
+title: Enterprise Deployment
+sidebar_label: Enterprise Deployment
+description: Deploy Permit MCP Gateway within your own infrastructure — keep MCP traffic inside your network, meet data residency requirements, and unlock enterprise security controls.
+sidebar_position: 10
+---
+
+# Enterprise Deployment
+
+For organizations that need MCP gateway enforcement **within their own network boundary**, Permit offers two enterprise deployment models — from running the gateway and PDP locally while using Permit.io as the cloud control plane, to a **fully on-premises deployment** where the entire stack — including the control plane — runs in your environment with no external dependencies.
+
+:::info Getting Started
+Enterprise deployment is available on **Enterprise plans**. The [hosted gateway](/permit-mcp-gateway/overview#hosted-gateway-saas) is the recommended starting point for evaluation — you can migrate to customer-controlled deployment at any time without losing policies, users, or audit history.
+:::
+
+---
+
+## Why Deploy On-Premises
+
+### Data Residency and Compliance
+
+In the hosted deployment, MCP traffic — including tool call parameters and upstream server responses — flows through Permit's managed infrastructure. For many organizations this is acceptable, but some requirements demand more:
+
+- **Regulated industries** — healthcare (HIPAA), financial services (SOX, PCI-DSS), and government (FedRAMP) environments where data must not leave approved network boundaries
+- **Data residency laws** — GDPR, data sovereignty regulations, or contractual obligations that restrict where data can be processed
+- **Internal policy** — organizations with blanket requirements that production traffic stays within corporate infrastructure
+
+With customer-controlled deployment, **MCP traffic never leaves your network**. The gateway runs inside your VPC or on-premises data center, and tool calls are proxied directly to upstream MCP servers without traversing external infrastructure.
+
+### Network-Level Control
+
+Running the gateway in your own environment gives you full control over the network layer:
+
+- **Private MCP servers** — proxy to internal MCP servers that are not exposed to the internet, without opening firewall rules
+- **Network segmentation** — place the gateway in a dedicated security zone with controlled ingress/egress
+- **VPC peering** — connect directly to upstream services over private links, eliminating public internet hops
+- **Custom TLS** — use your own certificates and PKI infrastructure
+- **IP allow-listing** — control which networks can reach the gateway, beyond application-layer authentication
+
+### Low-Latency Authorization
+
+The hosted gateway evaluates authorization decisions against Permit's cloud PDP. In customer-controlled deployments, you can run a **local PDP** alongside the gateway:
+
+- **Sub-millisecond authorization** — policy decisions evaluated locally, no network round-trip to the cloud
+- **Resilience** — authorization continues even if internet connectivity to Permit.io is temporarily interrupted
+- **Predictable latency** — no variability from cross-region PDP calls; performance is bounded by local compute
+
+In the customer-controlled model, Permit.io still serves as the cloud control plane — policy changes propagate to your local PDP automatically via [OPAL](https://www.opal.ac/), with no manual sync required. For fully on-premises deployments, the control plane also runs locally — see [Fully On-Premises Deployment](#fully-on-premises-deployment) below.
+
+---
+
+## Deployment Models
+
+Permit MCP Gateway supports three deployment models. Choose based on your compliance, network, and operational requirements:
+
+| Aspect | Hosted (SaaS) | Customer-Controlled | Fully On-Premises |
+| --- | --- | --- | --- |
+| **Gateway location** | Managed by Permit at `*.agent.security` | Runs in your VPC, on-prem, or private cloud | Runs in your environment |
+| **MCP traffic path** | Through Permit's managed infrastructure | Stays entirely within your network | Stays entirely within your network |
+| **Authorization decisions** | Permit.io cloud PDP | Local PDP in your environment | Local PDP in your environment |
+| **Policy management (control plane)** | Permit.io cloud | Permit.io cloud | **On-premises control plane** — runs in your environment |
+| **Audit logs** | Permit.io cloud storage | Your infrastructure + Permit.io (configurable) | **Fully local** — no data leaves your network |
+| **TLS certificates** | Managed by Permit | Your certificates, your PKI | Your certificates, your PKI |
+| **Private MCP servers** | Must be internet-accessible | Accessible over private network | Accessible over private network |
+| **Internet connectivity required** | Yes | Yes (for control plane sync) | **No** — supports air-gapped environments |
+| **Uptime dependency** | Permit infrastructure | Your infrastructure + Permit.io for policy updates | **Fully self-contained** — no external dependencies |
+| **Best for** | Fast adoption, SaaS workloads, evaluation | Data residency, private MCP servers, local PDP | Air-gapped, classified, and zero-trust environments |
+
+### What Stays the Same Across All Models
+
+All deployment models use the **same gateway codebase, same policy model, and same authorization logic**. The differences are purely about where components run and where traffic flows:
+
+- Same ReBAC policy model with trust levels, consent, and the `min()` ceiling logic
+- Same MCP client configuration — users just point to your internal gateway URL instead of `*.agent.security`
+- Same admin dashboard experience for gateway management
+- Same policy inspection and audit log capabilities
+- Policies, users, and audit history can be migrated seamlessly between deployment models
+
+---
+
+## Fully On-Premises Deployment
+
+For organizations with the strictest security requirements, Permit offers a **fully on-premises deployment** where the entire stack runs within your environment — including the control plane. No component communicates with external services, and no data leaves your network.
+
+### What's Included
+
+The fully on-premises package includes everything needed to run the complete Permit MCP Gateway stack independently:
+
+- **Gateway** — the MCP proxy with authentication and authorization enforcement
+- **Consent Service** — user-facing OAuth 2.1 authorization server and consent UI
+- **Policy Decision Point (PDP)** — local authorization engine for real-time `permit.check()` evaluations
+- **Control Plane** — policy management, resource schemas, role assignments, and audit log storage — all running locally
+- **Admin Dashboard** — the same gateway management UI, hosted within your infrastructure
+- **Policy Dashboard** — full policy inspection, audit log analysis, and configuration — running on-premises
+
+### Air-Gapped Environments
+
+The fully on-premises deployment is designed to operate in **air-gapped environments** with no internet connectivity:
+
+- **No outbound connections** — the gateway, PDP, control plane, and all supporting services run entirely within your network boundary. There is no phone-home, telemetry, or license check that requires internet access.
+- **Offline policy management** — policies are created, modified, and evaluated locally. Changes propagate from the on-premises control plane to the local PDP without any external dependency.
+- **Self-contained updates** — software updates are delivered as versioned artifacts (container images, binaries) that can be transferred into the air-gapped environment via your existing secure media processes.
+- **Local audit storage** — all audit logs, consent records, and session data are stored within your infrastructure. No data is transmitted externally.
+
+### When to Choose Fully On-Premises
+
+This deployment model is designed for environments where external connectivity is not an option:
+
+- **Defense and intelligence** — classified environments where systems must operate within secure enclaves with no internet access
+- **Critical infrastructure** — energy, utilities, and industrial control environments with strict network isolation requirements
+- **Government and public sector** — agencies subject to FedRAMP High, ITAR, or similar frameworks that mandate complete infrastructure control
+- **Healthcare with strict data isolation** — environments where even policy metadata must remain within the compliance boundary
+- **Financial institutions with zero-trust mandates** — organizations that require every component — including policy management — to run within their security perimeter
+
+---
+
+## Enterprise Security Controls
+
+Enterprise deployment unlocks additional security capabilities beyond the core gateway features available on all plans.
+
+### Agent Interrogation
+
+An agentic-native identity mechanism that engages connecting agents directly through the MCP protocol — verifying their identity, purpose, and behavioral fingerprint before any tools are unlocked. Agent Interrogation provides:
+
+- **Composite agent identity** — binds the delegating human, workflow context, and agent fingerprint into a single identity used for all policy and audit decisions
+- **Drift detection** — detects changes in agent behavior across sessions, surfacing potential prompt injection or configuration drift
+- **Per-workflow policy** — define different trust levels for the same MCP client operating in different contexts
+
+See [Advanced Features: Agent Interrogation](/permit-mcp-gateway/advanced-features#agent-interrogation) for the full technical details.
+
+### Human-in-the-Loop Approvals
+
+Pause agent execution for sensitive operations and route approval requests to designated reviewers. Routine operations continue uninterrupted — only high-risk actions require human confirmation.
+
+### Time-Limited Consent
+
+Set custom consent windows that automatically expire. Grant a contractor's agent two-week access, a vendor integration 90-day access, or a production debugging session 4-hour access — when the window closes, access is revoked automatically.
+
+### Additional Enterprise Controls
+
+- **Agent Verification** — behavioral profiling and identity baseline tracking across sessions
+- **Session Monitoring** — compare declared intent vs. actual tool call patterns, with anomaly surfacing
+- **Permission Receipts** — auditable records of every permission grant for compliance reporting
+- **Intent-Based Access Control** — evaluate agent purpose against policy before execution begins
+
+See [Advanced Features](/permit-mcp-gateway/advanced-features) for the full list and maturity status of each capability.
+
+---
+
+## Deployment Scenarios
+
+### Scenario 1: Regulated Environment
+
+A healthcare organization needs AI agents to interact with internal EHR and scheduling systems via MCP, but HIPAA requires that patient data never leaves the corporate network.
+
+**Solution:** Deploy the gateway and local PDP inside the hospital's private cloud. Internal MCP servers (EHR, scheduling) are accessible over the private network. Tool calls containing patient data stay within the compliance boundary. Permit.io serves as the control plane for policy management — only policy metadata (not patient data) is exchanged with the cloud.
+
+### Scenario 2: Financial Services with Private APIs
+
+A bank exposes internal trading and risk systems as MCP servers. These APIs are only accessible within the bank's VPC and cannot be exposed to the internet.
+
+**Solution:** Deploy the gateway inside the VPC with direct network access to internal MCP servers. Agents connect to the gateway over the corporate VPN or internal network. Authorization decisions are made locally for sub-millisecond latency on high-frequency tool calls.
+
+### Scenario 3: Multi-Region Enterprise
+
+A global enterprise needs gateway instances in multiple regions to comply with data sovereignty requirements and minimize latency.
+
+**Solution:** Deploy independent gateway instances in each region, each with its own local PDP. All instances share the same Permit.io control plane, so policies are consistent. MCP traffic stays within the regional network boundary.
+
+### Scenario 4: Air-Gapped Defense Environment
+
+A defense contractor needs AI agents to interact with classified systems via MCP inside a secure enclave with no internet connectivity.
+
+**Solution:** Deploy the fully on-premises stack — gateway, consent service, PDP, and control plane — entirely within the air-gapped network. Software updates are delivered via secure media transfer. Policies are managed through the on-premises admin dashboard. All audit data stays within the enclave. No component requires or attempts external communication.
+
+### Scenario 5: Hybrid — Hosted + Customer-Controlled
+
+An organization starts with the hosted gateway for non-sensitive workloads (e.g., Jira, Linear, GitHub) and deploys a customer-controlled instance for internal systems containing sensitive data.
+
+**Solution:** Run both deployments simultaneously. Users connect to the hosted gateway for external MCP servers and to the internal gateway for private ones. Both share the same Permit.io organization, providing a unified policy and audit view across deployments.
+
+---
+
+## Migration Path
+
+Organizations typically follow this path:
+
+1. **Evaluate with hosted** — start with the hosted gateway to validate the product, onboard pilot users, and define trust level policies. No infrastructure investment required.
+2. **Decide on deployment model** — based on your compliance, data residency, and network requirements, determine which model fits:
+   - **Customer-controlled** — gateway and PDP in your environment, Permit.io cloud as control plane
+   - **Fully on-premises** — the entire stack in your environment, including the control plane, with air-gapped support
+3. **Deploy** — Permit provides the gateway artifacts, PDP images, control plane packages (for fully on-prem), and deployment guidance for your target environment (Kubernetes, Docker, VMs). Your existing policies, users, and configurations carry over.
+4. **Operate** — manage policies through the admin dashboard (cloud or on-premises, depending on your model). Monitor audit logs in your preferred location.
+
+:::tip Evaluate First
+We recommend starting with the [hosted gateway](/permit-mcp-gateway/quickstart) even if you know you'll need customer-controlled deployment. This lets you validate fit, define policies, and onboard pilot users without infrastructure setup — then migrate seamlessly when ready.
+:::
+
+---
+
+## Get Started
+
+Enterprise deployment is designed and scoped in collaboration with your team to ensure it meets your specific compliance, network, and operational requirements.
+
+- **[Schedule a demo](https://calendly.com/permit-io/demo)** — see the enterprise deployment in action and discuss your architecture
+- **[Contact us](mailto:support@permit.io)** — reach out with specific compliance or deployment questions
+- **[Join our Slack](https://io.permit.io/slack)** — talk with the team and other enterprise users
+
+Ready to evaluate? Start with the [Quick Start](/permit-mcp-gateway/quickstart) to set up a hosted gateway in under 5 minutes.

--- a/docs/permit-mcp-gateway/host-setup.mdx
+++ b/docs/permit-mcp-gateway/host-setup.mdx
@@ -320,3 +320,7 @@ Adopting Permit MCP Gateway incrementally reduces risk and builds organizational
 - **Review before broadening** — inspect audit logs after each phase before adding more users or servers
 - **Document trust level decisions** — record why specific tools were classified at specific levels, especially any manual overrides
 - **Keep direct access disabled** — remove direct MCP server connections from client configs to prevent agents from bypassing the gateway
+
+:::tip Enterprise Deployment
+If your organization requires the gateway inside your own network — for data residency, private MCP servers, or compliance — see the [Enterprise Deployment](/permit-mcp-gateway/enterprise-deployment) guide. You can evaluate with the hosted gateway and migrate seamlessly when ready.
+:::

--- a/docs/permit-mcp-gateway/index.mdx
+++ b/docs/permit-mcp-gateway/index.mdx
@@ -62,7 +62,7 @@ See [Permit.io Integration](/permit-mcp-gateway/permit-integration/) for the det
 - [**Architecture**](/permit-mcp-gateway/architecture/) — Technical architecture, data flows, and sequence diagrams
 - [**Permit.io Integration**](/permit-mcp-gateway/permit-integration/) — Policy engine internals and authorization model
 - [**Advanced Features**](/permit-mcp-gateway/advanced-features/) — Enterprise capabilities and roadmap
-- [**Enterprise Deployment**](/permit-mcp-gateway/enterprise-deployment/) — Customer-controlled deployment for regulated environments and data residency
+- [**Enterprise Deployment**](/permit-mcp-gateway/enterprise-deployment) — Customer-controlled and on-premises deployment for regulated environments and data residency
 
 ## Prerequisites
 

--- a/docs/permit-mcp-gateway/index.mdx
+++ b/docs/permit-mcp-gateway/index.mdx
@@ -62,6 +62,7 @@ See [Permit.io Integration](/permit-mcp-gateway/permit-integration/) for the det
 - [**Architecture**](/permit-mcp-gateway/architecture/) — Technical architecture, data flows, and sequence diagrams
 - [**Permit.io Integration**](/permit-mcp-gateway/permit-integration/) — Policy engine internals and authorization model
 - [**Advanced Features**](/permit-mcp-gateway/advanced-features/) — Enterprise capabilities and roadmap
+- [**Enterprise Deployment**](/permit-mcp-gateway/enterprise-deployment/) — Customer-controlled deployment for regulated environments and data residency
 
 ## Prerequisites
 

--- a/docs/permit-mcp-gateway/overview.mdx
+++ b/docs/permit-mcp-gateway/overview.mdx
@@ -251,7 +251,7 @@ Key benefits of customer-controlled deployment:
 
 - **Data stays in your network** — MCP traffic (tool call parameters, upstream responses) never leaves your VPC or data center
 - **Private MCP servers** — proxy to internal servers that aren't exposed to the internet
-- **Local PDP** — sub-millisecond authorization decisions with no external network dependency
+- **Local PDP** — low-latency authorization decisions with no external network dependency
 - **Same policy model** — identical ReBAC trust levels, consent flows, and audit logging as the hosted version
 
 For the strictest requirements, Permit also offers a **fully on-premises deployment** where the entire stack — including the control plane — runs within your environment. This supports **air-gapped environments** with no internet connectivity and no external dependencies.

--- a/docs/permit-mcp-gateway/overview.mdx
+++ b/docs/permit-mcp-gateway/overview.mdx
@@ -156,19 +156,16 @@ This section describes what Permit MCP Gateway enforces, what it logs, and what 
 - Agent-to-server session creation and expiry
 - All logs are available via the Permit MCP Gateway dashboard and the Permit.io audit log API
 
-### Hosted vs. Customer-Controlled Deployment
+### Deployment Models
 
-| Aspect | Hosted | Customer-Controlled | Fully On-Premises |
-| --- | --- | --- | --- |
-| **Gateway location** | Managed by Permit at `*.agent.security` | Runs in your environment (VPC, on-prem) | Runs in your environment |
-| **Control plane** | Permit.io cloud | Permit.io cloud | **On-premises** — runs in your environment |
-| **Policy decisions** | Evaluated by Permit.io cloud PDP | Evaluated by a local PDP | Evaluated by a local PDP |
-| **Data in transit** | MCP traffic flows through the hosted gateway | MCP traffic stays within your network | **All data** stays within your network |
-| **Internet required** | Yes | Yes (for control plane) | **No** — supports air-gapped environments |
-| **Best for** | Fast adoption, SaaS workloads, evaluation | Data residency, private MCP servers | Air-gapped, classified, zero-trust environments |
+Permit MCP Gateway supports three deployment models. For a full comparison, see the [Enterprise Deployment](/permit-mcp-gateway/enterprise-deployment#deployment-models) guide.
+
+- **Hosted (SaaS)** — managed by Permit at `*.agent.security`. Fast adoption, no infrastructure to manage. Available on all plans.
+- **Customer-Controlled** — gateway and PDP run in your environment (VPC, on-prem). MCP traffic stays within your network. Permit.io remains the control plane.
+- **Fully On-Premises** — the entire stack, including the control plane, runs in your environment. Supports air-gapped environments with no internet connectivity.
 
 :::note
-Customer-controlled deployment is available for enterprise plans. [Contact us](mailto:support@permit.io) for architecture details. The hosted deployment is available for all plans and is the recommended starting point.
+Customer-controlled and fully on-premises deployments are available on Enterprise plans. [Schedule a demo](https://calendly.com/permit-io/demo) to discuss your requirements. The hosted deployment is available for all plans and is the recommended starting point.
 :::
 
 ### What Risks the Gateway Mitigates
@@ -256,10 +253,10 @@ Key benefits of customer-controlled deployment:
 
 For the strictest requirements, Permit also offers a **fully on-premises deployment** where the entire stack — including the control plane — runs within your environment. This supports **air-gapped environments** with no internet connectivity and no external dependencies.
 
-See the full [Enterprise Deployment](/permit-mcp-gateway/enterprise-deployment) guide for architecture details, deployment scenarios, and migration path.
+See the full [Enterprise Deployment](/permit-mcp-gateway/enterprise-deployment) guide for deployment models, enterprise security controls, and air-gapped support.
 
 :::note
-Customer-controlled and fully on-premises deployments are available on Enterprise plans. [Schedule a demo](https://calendly.com/permit-io/demo) to discuss your requirements, or start with the [hosted gateway](/permit-mcp-gateway/quickstart) to evaluate — policies and users migrate seamlessly.
+Customer-controlled and fully on-premises deployments are available on Enterprise plans. [Schedule a demo](https://calendly.com/permit-io/demo) to discuss your requirements, or start with the [hosted gateway](/permit-mcp-gateway/quickstart) to evaluate — policies and users can be migrated between deployment models.
 :::
 
 ---

--- a/docs/permit-mcp-gateway/overview.mdx
+++ b/docs/permit-mcp-gateway/overview.mdx
@@ -158,12 +158,14 @@ This section describes what Permit MCP Gateway enforces, what it logs, and what 
 
 ### Hosted vs. Customer-Controlled Deployment
 
-| Aspect | Hosted | Customer-Controlled |
-| --- | --- | --- |
-| **Gateway location** | Managed by Permit at `*.agent.security` | Runs in your environment (VPC, on-prem) |
-| **Policy decisions** | Evaluated by Permit.io cloud PDP | Can be evaluated by a local PDP |
-| **Data in transit** | MCP traffic flows through the hosted gateway | MCP traffic stays within your network |
-| **Best for** | Fast adoption, SaaS workloads, evaluation | Regulated environments, data residency requirements |
+| Aspect | Hosted | Customer-Controlled | Fully On-Premises |
+| --- | --- | --- | --- |
+| **Gateway location** | Managed by Permit at `*.agent.security` | Runs in your environment (VPC, on-prem) | Runs in your environment |
+| **Control plane** | Permit.io cloud | Permit.io cloud | **On-premises** — runs in your environment |
+| **Policy decisions** | Evaluated by Permit.io cloud PDP | Evaluated by a local PDP | Evaluated by a local PDP |
+| **Data in transit** | MCP traffic flows through the hosted gateway | MCP traffic stays within your network | **All data** stays within your network |
+| **Internet required** | Yes | Yes (for control plane) | **No** — supports air-gapped environments |
+| **Best for** | Fast adoption, SaaS workloads, evaluation | Data residency, private MCP servers | Air-gapped, classified, zero-trust environments |
 
 :::note
 Customer-controlled deployment is available for enterprise plans. [Contact us](mailto:support@permit.io) for architecture details. The hosted deployment is available for all plans and is the recommended starting point.
@@ -241,12 +243,23 @@ The fastest way to get started. Each gateway host runs under a subdomain of `age
 - **Minutes to first value** — create a host, import a server, connect a client
 - **Isolated per host** — each host gets its own subdomain, users, policies, and sessions
 
-### Customer-Controlled Deployment
+### Customer-Controlled Deployment (Enterprise)
 
-For organizations that require enforcement within their own network boundary, Permit offers deployment options where the gateway and policy decision point (PDP) run in your environment. Permit.io still serves as the control plane, but authorization decisions and MCP traffic stay within your network.
+For organizations that require enforcement within their own network boundary, Permit offers deployment options where the gateway and policy decision point (PDP) run in your environment. Permit.io still serves as the control plane, but authorization decisions and MCP traffic stay entirely within your network.
+
+Key benefits of customer-controlled deployment:
+
+- **Data stays in your network** — MCP traffic (tool call parameters, upstream responses) never leaves your VPC or data center
+- **Private MCP servers** — proxy to internal servers that aren't exposed to the internet
+- **Local PDP** — sub-millisecond authorization decisions with no external network dependency
+- **Same policy model** — identical ReBAC trust levels, consent flows, and audit logging as the hosted version
+
+For the strictest requirements, Permit also offers a **fully on-premises deployment** where the entire stack — including the control plane — runs within your environment. This supports **air-gapped environments** with no internet connectivity and no external dependencies.
+
+See the full [Enterprise Deployment](/permit-mcp-gateway/enterprise-deployment) guide for architecture details, deployment scenarios, and migration path.
 
 :::note
-Customer-controlled deployment is available for enterprise plans. [Contact us](mailto:support@permit.io) or [schedule a demo](https://calendly.com/permit-io/demo) for architecture details and availability.
+Customer-controlled and fully on-premises deployments are available on Enterprise plans. [Schedule a demo](https://calendly.com/permit-io/demo) to discuss your requirements, or start with the [hosted gateway](/permit-mcp-gateway/quickstart) to evaluate — policies and users migrate seamlessly.
 :::
 
 ---

--- a/sidebars.js
+++ b/sidebars.js
@@ -215,6 +215,7 @@ const sidebars = {
             "permit-mcp-gateway/architecture",
             "permit-mcp-gateway/permit-integration",
             "permit-mcp-gateway/advanced-features",
+            "permit-mcp-gateway/enterprise-deployment",
             {
               type: "category",
               label: "Usage Examples and Demos",


### PR DESCRIPTION
## Summary
- New **Enterprise Deployment** page covering three deployment models: hosted SaaS, customer-controlled (gateway + PDP local, cloud control plane), and fully on-premises (entire stack including control plane, air-gapped support)
- Expanded overview comparison table from 2 columns to 3 (hosted / customer-controlled / fully on-prem) with internet requirement and control plane rows
- Cross-linked from overview, architecture, advanced features, host setup, and index pages
- Added to sidebar after Advanced Features

## What's on the new page
- Why deploy on-premises (data residency, network control, low-latency PDP)
- 3-column deployment model comparison table
- Fully on-premises details: what's included, air-gapped support, when to choose it
- Enterprise security controls summary (with maturity context link)
- Get Started CTAs (demo, contact, Slack)

## Test plan
- [ ] Verify the new page renders correctly in Docusaurus
- [ ] Check all internal cross-links resolve (overview, architecture, advanced-features, host-setup, index → enterprise-deployment)
- [ ] Review content with product/sales — especially fully on-prem and air-gapped positioning
- [ ] Verify sidebar ordering looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)