### PR TITLE
docs(mcp-gateway): outbound credential brokering + dynamic short-lived credentials (PR 4e)

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,10 @@
       "JWKS",
       "colour",
       "customising",
-      "gitops"
+      "gitops",
+      "SigV4",
+      "IRSA",
+      "HashiCorp",
+      "EKS"
   ]
 }

--- a/docs/permit-mcp-gateway/advanced-features.mdx
+++ b/docs/permit-mcp-gateway/advanced-features.mdx
@@ -115,6 +115,12 @@ Define what each agent is allowed to do by declaring its intended purpose up fro
 Intent-based access control is an emerging capability. [Contact us](mailto:support@permit.io) for current status and roadmap.
 :::
 
+## Outbound Credential Brokering
+
+Let agents call upstream APIs without ever holding the API's long-lived secret. The gateway injects the credential per request, scrubs it from the response, and can mint **short-lived, identity-scoped credentials just in time** — AWS STS temporary credentials (SigV4-signed) or OAuth access tokens minted from a vaulted refresh token that never leaves the gateway.
+
+See the dedicated **[Outbound Credentials](/permit-mcp-gateway/outbound-credentials)** guide for full documentation.
+
 ---
 
 ## Feature Maturity Summary
@@ -128,6 +134,7 @@ Intent-based access control is an emerging capability. [Contact us](mailto:suppo
 | **Session Monitoring** | Enterprise, early access | Anomaly detection capabilities under active development |
 | **Permission Receipts** | Enterprise | Available for enterprise plans |
 | **Intent-Based Access Control** | Enterprise, roadmap | Declared intent captured via Agent Interrogation, policy evaluation emerging |
+| **[Outbound Credential Brokering](/permit-mcp-gateway/outbound-credentials)** | Static available; dynamic (AWS STS, OAuth) active development | Per-request credential injection + response scrubbing; short-lived AWS/OAuth credentials minted just in time |
 
 :::info Items flagged on the marketing site but not yet detailed in documentation
 The following capabilities have been referenced in marketing materials but are not yet fully documented. Contact us for current status:

--- a/docs/permit-mcp-gateway/outbound-credentials.mdx
+++ b/docs/permit-mcp-gateway/outbound-credentials.mdx
@@ -50,6 +50,61 @@ A leaked long-lived key is valid until someone notices and rotates it. A minted 
 
 To avoid calling AWS STS or your identity provider on every single request, the gateway caches a minted credential for a window **shorter than its real lifetime** and refreshes it before it expires — so a burst of agent traffic reuses one mint, and an expired credential is never reused. The cache is isolated per tenant: a credential minted for one organization's agent is never served to another.
 
+## Connecting a provider
+
+Instead of hand-creating a token and pasting it in, you can **connect a provider** and let the gateway obtain the credential for you through the provider's standard OAuth flow. Supported providers today: **GitHub App, Notion, Google, and Atlassian**.
+
+Here the gateway acts as an OAuth **client to the provider** — this is separate from the gateway's own login (the consent service). You supply your registered OAuth app's client ID (and client secret, if the provider is confidential), and the gateway walks the authorization:
+
+1. From the dashboard, open a credential, choose the **OAuth** type and a provider, then click **Connect**. A confirmation explains what will be authorized and that the token is stored encrypted and never shown to agents.
+2. A provider window opens for you to authorize. The gateway requests authorization using **PKCE** and a one-time **state** value bound to your workspace.
+3. The provider redirects back to the gateway, which verifies the state, exchanges the code, and stores the result. If the provider issues a **refresh token**, it is stored as a short-lived (`OAuth`) credential and the refresh token stays in the vault; otherwise the provider's long-lived token is stored as a static credential.
+4. The dashboard resolves to **Connected** and the credential is ready to use. If you decline at the provider, the window is closed, or anything fails the security check, **nothing is stored** and you can retry.
+
+To reconnect later (for example to grant additional scopes), use **Reconnect** on the credential.
+
+The same flow is available headlessly from the CLI:
+
+```bash
+asg proxy connect github_app --key github-prod --client-id <your-client-id>
+```
+
+This opens your browser to authorize and waits until the credential is connected.
+
+## Preset packs — one-command provider setup
+
+A **preset pack** configures a known provider end-to-end in one action: instead of hand-writing the proxy rules and creating the credential separately, you apply a pack and the gateway sets up both. A pack bundles the rules to govern a provider's API hosts plus a credential skeleton (and, where the provider supports it, a reference to the OAuth connect flow above). Packs are **data, not code** — the catalog ships with the gateway and can be extended without a release.
+
+The seeded catalog includes providers such as GitHub, Notion, Google Vertex AI, Datadog, Cloudflare, OpenAI, Slack, Todoist, AWS S3, and MongoDB Atlas.
+
+### Applying a pack is always preview-first
+
+Applying a pack changes your egress policy, so it is never blind — you always see exactly what it will create before anything is written:
+
+- The preview shows the **exact proxy rules** (host, path, method, action) the pack will create, the **credential** it will set up, and a clear **"what you still need to provide"** step (paste an API key, connect a provider, or finish a role/client-credentials setup).
+- **Conflicts are flagged, never silent.** A rule identical to one you already have is skipped; a rule that an existing higher-precedence rule would shadow is called out; an existing credential of the same name is never overwritten.
+- Nothing is written until you confirm.
+
+In the dashboard, open **Proxy → Presets**, pick a provider, and click **Configure** to see the preview, then **Apply**. After applying you can jump to the created rules and credential from the success panel. If the pack needs an OAuth connection or a secret you didn't provide, the credential shows **Action needed — finish the credential** until you complete it (paste the API key, or run Connect for OAuth packs).
+
+From the CLI, the same flow previews first and asks you to confirm:
+
+```bash
+asg proxy preset list
+asg proxy preset apply datadog            # previews, then prompts to confirm
+asg proxy preset apply datadog --secret "$DD_API_KEY" --yes   # non-interactive (CI)
+```
+
+For an OAuth provider, applying the pack sets up the rules and then points you at the connect step (`asg proxy connect …`) to finish the credential.
+
+### Verified vs Community packs
+
+Each pack carries a **provenance** badge. **Verified** packs are seeded and maintained by Permit; **Community** packs are contributed. Because applying a pack writes egress policy, the provenance is always shown so you can decide how much to trust it before applying.
+
+### Authoring or contributing a pack
+
+A pack is a small declarative file (rules + a credential skeleton + what the operator must provide). To contribute a pack for a provider that isn't covered yet, add a pack file and open a pull request against the gateway repository — the catalog validates every contributed pack (a pack cannot, for example, create an over-broad rule or bind a credential to a host its own rules don't govern). There is no runtime upload of untrusted packs.
+
 ## Security summary
 
 - The agent never holds the upstream secret — the gateway injects it per request and scrubs it from responses.
@@ -57,6 +112,8 @@ To avoid calling AWS STS or your identity provider on every single request, the 
 - The OAuth refresh token and any client secret stay in the encrypted vault — never injected, never logged.
 - A credential is only ever sent to the hosts it is explicitly bound to.
 - Credentials and grants are encrypted at rest and isolated per tenant.
+- The provider connect flow uses PKCE and a one-time, workspace-bound state value; a connection started for one workspace cannot complete in another, and a declined or failed connect stores nothing.
+- Preset packs are preview-first: applying one shows the exact rules and credential it will create, flags any conflicting or shadowed rules, and never overwrites an existing credential or creates an over-broad / cross-host binding.
 
 ## Requirements for AWS STS
 

--- a/docs/permit-mcp-gateway/outbound-credentials.mdx
+++ b/docs/permit-mcp-gateway/outbound-credentials.mdx
@@ -1,0 +1,77 @@
+---
+title: Outbound Credentials
+sidebar_label: Outbound Credentials
+description: Let agents call upstream APIs without ever holding a long-lived secret. The Permit MCP Gateway brokers outbound credentials — injecting them per request, scrubbing them from responses, and minting short-lived AWS and OAuth credentials just in time.
+sidebar_position: 8.5
+---
+
+# Outbound Credentials
+
+When an agent needs to call an upstream API — Stripe, GitHub, an AWS service, an internal microservice — it normally needs that service's credential. Handing the agent a long-lived API key is exactly the risk you adopted the gateway to avoid: the key lives in the agent's context, can leak through logs or prompt injection, and outlives the task.
+
+The Permit MCP Gateway acts as an **outbound credential broker**. The agent's outbound HTTP traffic is routed through the gateway; for each request the gateway authorizes the destination against policy, injects the right credential, forwards the request, and **scrubs the credential out of the response** before the agent sees it. The agent calls the API successfully but never observes the secret.
+
+:::note Plan availability
+Outbound credential brokering is part of the gateway's proxy capabilities. Dynamic / short-lived issuance (AWS STS and OAuth, below) is an Enterprise capability under active development — [schedule a demo](https://calendly.com/permit-io/demo) to discuss availability and fit.
+:::
+
+## How it works
+
+1. The agent is configured to send its outbound API traffic through the gateway.
+2. The gateway authorizes the destination host (and path/method) against your policy — the same identity-and-policy model used for MCP tool calls, including [human-in-the-loop approvals](/permit-mcp-gateway/human-in-the-loop) and rate limiting.
+3. The gateway injects the credential bound to that destination, and only toward hosts that credential is explicitly allowed to reach (a credential scoped to `api.stripe.com` can never be sent to another host, even if a broader rule allowed the request).
+4. The response is streamed back with the injected credential — and its common encodings — **redacted**, so an upstream that echoes the credential back (a diagnostic endpoint, an error message, a logging proxy) cannot leak it to the agent.
+
+The credential is stored encrypted at rest and is **write-only** in the admin surface — it is never returned once configured, and never exposed to the agent.
+
+## Credential types
+
+A credential is configured per destination. Three types are supported, spanning stored secrets and just-in-time issuance.
+
+### Static secret
+
+A stored long-lived secret (an API key, a token, a username/password) injected as a request header, a query parameter, or HTTP Basic auth. Use this for services that only issue long-lived keys. The secret is encrypted at rest and scrubbed from responses, but it is still a standing secret — prefer a dynamic type below where the provider supports it.
+
+### AWS STS — short-lived, role-scoped credentials
+
+Instead of storing an AWS access key, configure the **IAM role** the agent's calls should assume. For each request the gateway calls AWS STS to assume that role, receives **temporary credentials**, and signs the upstream request with AWS SigV4. **No long-lived AWS key is ever stored or injected** — the credentials are minted on demand, scoped to the role you choose, and expire automatically.
+
+The gateway authenticates to AWS with its own deployment identity (for example, an EKS IRSA role) — not a per-tenant standing secret — and can only assume the role configured in your own credential record. The temporary session token is scrubbed from responses like any other secret.
+
+### OAuth — minted from a stored grant
+
+For providers that issue refreshable OAuth tokens, the gateway stores the **refresh token** in its encrypted vault and mints a **short-lived access token** for each request window. The agent's request carries only the short-lived access token; **the refresh token never leaves the vault, is never injected into an upstream request, and is never logged**. When the access token nears expiry the gateway refreshes it transparently.
+
+:::info Why short-lived matters
+A leaked long-lived key is valid until someone notices and rotates it. A minted credential is scoped to a single role or grant and expires in minutes — so even in the worst case, the blast radius and the exposure window are small by construction. This is the same just-in-time model used by AWS STS, HashiCorp Vault dynamic secrets, and modern secrets brokers.
+:::
+
+## Caching and freshness
+
+To avoid calling AWS STS or your identity provider on every single request, the gateway caches a minted credential for a window **shorter than its real lifetime** and refreshes it before it expires — so a burst of agent traffic reuses one mint, and an expired credential is never reused. The cache is isolated per tenant: a credential minted for one organization's agent is never served to another.
+
+## Security summary
+
+- The agent never holds the upstream secret — the gateway injects it per request and scrubs it from responses.
+- Dynamic credentials (AWS STS, OAuth) are short-lived and identity-scoped; no standing secret is stored for them.
+- The OAuth refresh token and any client secret stay in the encrypted vault — never injected, never logged.
+- A credential is only ever sent to the hosts it is explicitly bound to.
+- Credentials and grants are encrypted at rest and isolated per tenant.
+
+## Requirements for AWS STS
+
+Using AWS STS credentials requires a small amount of AWS-side setup, typically handled by your platform team:
+
+- The gateway's deployment identity must be allowed to assume each configured role.
+- Each target role's trust policy must permit the gateway to assume it — in multi-tenant deployments, scoped with a per-tenant external ID.
+- The target role's maximum session duration must be at least the session lifetime you configure.
+
+See [Enterprise Deployment](/permit-mcp-gateway/enterprise-deployment) for customer-controlled deployment and infrastructure details.
+
+:::note Maturity
+Dynamic credential issuance (AWS STS and OAuth) is an Enterprise capability under active development. Static credential injection and response scrubbing are available today. [Contact us](mailto:support@permit.io) for current status, early access, and roadmap details.
+:::
+
+---
+
+**Interested?** [Schedule a demo](https://calendly.com/permit-io/demo) or reach out at [support@permit.io](mailto:support@permit.io). You can also find us on [Slack](https://io.permit.io/slack).


### PR DESCRIPTION
## Why

Companion customer-docs for **agent-security PR #295** (PER-14853, PR 4e — *Dynamic / Short-Lived Credential Issuance*). The gateway can now mint short-lived, identity-scoped credentials for agents' outbound API calls instead of storing a long-lived secret — a customer-facing behavioral change that needs documentation.

Linear: **PER-14853**.

## What

- **New page `docs/permit-mcp-gateway/outbound-credentials.mdx`** (sidebar 8.5): documents the gateway as an **outbound credential broker** — the agent never holds the upstream secret; the gateway injects it per request, authorizes the destination against policy, and scrubs the credential from the response. Covers the three credential types:
  - **Static** stored secret (header / query / basic auth).
  - **AWS STS** — assume the configured IAM role per request → temporary credentials → SigV4-signed request; no long-lived AWS key stored or injected.
  - **OAuth** — refresh token stays vaulted (never injected, never logged); only a short-lived minted access token is injected.
  - Plus caching/freshness, a security summary, and the AWS-side IAM requirements (assume-role permission, target-role trust policy + per-tenant external ID, `MaxSessionDuration`).
- **`advanced-features.mdx`**: new "Outbound Credential Brokering" section cross-linking the page + a Feature Maturity Summary row.
- **`cspell.json`**: added `SigV4`, `IRSA`, `HashiCorp`, `EKS`.

## How it was tested

Docs-only. Verified internal links resolve to existing pages (`human-in-the-loop`, `enterprise-deployment`, the new `outbound-credentials`), frontmatter matches the existing `permit-mcp-gateway` pages, and added the new technical terms to `cspell.json` so the spell-check passes. No emojis; Docusaurus admonitions used per house style.

## Notes

Dynamic issuance is flagged as an Enterprise capability under active development; static credential injection + response scrubbing are described as available today. Phrasing is intentionally conservative on maturity, matching the surrounding Advanced Features page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
