### PR TITLE
PER-15119: remove deprecated pdp-api.permit.io host from docs

### DIFF
--- a/docs/api/pdp-api-reference.mdx
+++ b/docs/api/pdp-api-reference.mdx
@@ -9,4 +9,4 @@ title: PDP API Reference
 
 Just like the Permit.io cloud service, the PDP exposes an OpenAPI spec which can be used to explore the API and develop your own SDKs.
 
-Assuming you're running your PDP at `localhost:7000` you can access the spec at `http://localhost:7000/openapi.json` and view the docs at `http://localhost:7000/redoc`.
+Assuming you're running your PDP at `localhost:7766` you can access the spec at `http://localhost:7766/openapi.json` and view the docs at `http://localhost:7766/redoc`.

--- a/docs/api/pdp-api-reference.mdx
+++ b/docs/api/pdp-api-reference.mdx
@@ -5,23 +5,8 @@ title: PDP API Reference
 
 # PDP API Reference
 
-## PDP/SDK OpenAPI spec - overview and evaluation purpose of online version
+## PDP/SDK OpenAPI spec
 
+Just like the Permit.io cloud service, the PDP exposes an OpenAPI spec which can be used to explore the API and develop your own SDKs.
 
-You can access and view the redoc at [https://pdp-api.permit.io/redoc](https://pdp-api.permit.io/redoc) which is embedded here:
-
-<iframe
-	style={{
-		boxShadow: "0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24)",
-		backgroundColor: "#FDFCFC",
-		maxWidth: "80vw",
-	}}
-	src={"https://pdp-api.permit.io/redoc"}
-	width={"1080px"}
-	height={"600px"}
-/>
-
-## PDP/SDK OpenAPI spec - local version
-
-Just like the Permit.io cloud service, the local PDP exposes an OpenAPI spec which can be used to develop your own SDKs.
 Assuming you're running your PDP at `localhost:7000` you can access the spec at `http://localhost:7000/openapi.json` and view the docs at `http://localhost:7000/redoc`.

--- a/docs/how-to/enforce-permissions/url-mapping/url-mapping-check.mdx
+++ b/docs/how-to/enforce-permissions/url-mapping/url-mapping-check.mdx
@@ -84,4 +84,4 @@ curl --location 'http://localhost:7766/allowed_url' \
 }'
 ```
 
-You can see more details about the payload in the [PDP API Redoc](https://pdp-api.permit.io/redoc#tag/Authorization-API/operation/is_allowed_url_allowed_url_post)
+You can see more details about the payload in the [PDP API Reference](/api/pdp-api-reference)

--- a/docs/sdk/nodejs/all-tenants.mdx
+++ b/docs/sdk/nodejs/all-tenants.mdx
@@ -10,7 +10,7 @@ title: All Tenants Check Examples
 To validate permissions irrespective of the tenant, you can use the permit.AllTenantsCheck function. This function determines if a user has permissions for a specified action
 on a resource across all tenants, the response will be a list of tenants in which the user is allowed to perform the request.
 :::note
-You can also find information about the All tenants check in the [Permit Authorization Redoc](https://pdp-api.permit.io/redoc#tag/Authorization-API/operation/is_allowed_all_tenants_allowed_all_tenants_post).
+You can also find information about the All tenants check in the [PDP API Reference](/api/pdp-api-reference).
 :::
 
 
@@ -23,7 +23,7 @@ To perform this check, send a GET request to the `/allowed/all-tenants` endpoint
 - **sdk**: The identifier for the SDK making the request.
 
 ```bash
-curl 'https://pdp-api.permit.io/allowed/all-tenants' \
+curl 'http://localhost:7766/allowed/all-tenants' \
   -X GET \
   -H 'Authorization: Bearer API_SECRET_KEY' \
   -D '{ "user": "employee1", "action": "read", "resource": "document", "context": {}, "sdk": "node" }'

--- a/src/sdks/walkthroughs/authz-queries/getAuthorizedUsers/example.bash
+++ b/src/sdks/walkthroughs/authz-queries/getAuthorizedUsers/example.bash
@@ -1,4 +1,4 @@
-curl https://pdp-api.permit.io/authorized_users \
+curl http://localhost:7766/authorized_users \
   --request POST \
   --header "Authorization: Bearer YOUR_SECRET_TOKEN" \
   --header "Content-Type: application/json" \

--- a/src/sdks/walkthroughs/authz-queries/getUserPermissions/example.bash
+++ b/src/sdks/walkthroughs/authz-queries/getUserPermissions/example.bash
@@ -1,4 +1,4 @@
-curl https://pdp-api.permit.io/user-permissions \
+curl http://localhost:7766/user-permissions \
   --request POST \
   --header "Authorization: Bearer YOUR_SECRET_TOKEN" \
   --header "Content-Type: application/json" \


### PR DESCRIPTION
## What

Removes all references to the shared public PDP host `pdp-api.permit.io` from the docs. That instance is a legacy/decommissioned PDP (no longer in use), so any docs pointing at it were either broken (the embedded online Redoc) or steering users at a shared host they shouldn't be calling.

## Changes

| File | Change |
|------|--------|
| `docs/api/pdp-api-reference.mdx` | Dropped the dead online Redoc `<iframe>` embed (`pdp-api.permit.io/redoc`); kept and tidied the local-PDP OpenAPI/Redoc guidance. |
| `docs/sdk/nodejs/all-tenants.mdx` | Redoc deep-link → internal [`/api/pdp-api-reference`](/api/pdp-api-reference); curl example host → `http://localhost:7766`. |
| `docs/how-to/enforce-permissions/url-mapping/url-mapping-check.mdx` | Redoc deep-link → internal `/api/pdp-api-reference`. |
| `src/sdks/walkthroughs/authz-queries/getAuthorizedUsers/example.bash` | curl host → `http://localhost:7766`. |
| `src/sdks/walkthroughs/authz-queries/getUserPermissions/example.bash` | curl host → `http://localhost:7766`. |

## Notes

- `http://localhost:7766` is the established local-PDP convention across the docs for these authz endpoints (`/allowed`, `/user-permissions`, `/authorized_users`), so the curl examples now match the rest of the docs.
- Left untouched: the `permit-pdp-api-key` GCP secret name in `gcp-cloud-run.mdx` — that's a secret name, not the host.
- The `api/pdp-api-reference` page (and its sidebar entry) is kept, just reframed around the local PDP, so no inbound links or sidebar entries break.
- Open question for reviewers: if we want to keep an *online* embedded Redoc, we could repoint it at `cloudpdp.api.permit.io/redoc` (the current hosted PDP) instead — left out here since the ask was to remove the dead host, not introduce a new embed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)