### PR TITLE
PER-14389: Migrate from Permit Cloud — self-service export + on-prem import guide

### DIFF
--- a/docs/how-to/deploy/on-prem/management.mdx
+++ b/docs/how-to/deploy/on-prem/management.mdx
@@ -95,7 +95,7 @@ kubectl get pods -n permit-platform
 # Health check endpoints
 curl -k https://your-domain.com/health              # Frontend health
 curl -k https://your-domain.com/scim/health         # SCIM health
-curl -k https://your-domain.com/api/v2/health       # Backend health
+curl -k https://your-domain.com/v2/healthy          # Backend health
 ```
 
 ## Configuration Management

--- a/docs/how-to/deploy/on-prem/migrate-from-cloud.mdx
+++ b/docs/how-to/deploy/on-prem/migrate-from-cloud.mdx
@@ -64,9 +64,6 @@ The response is your package: `permit-org-export-<org>-<timestamp>.tar.gz`. Extr
 - **Version alignment.** The package's `manifest.json` records the source schema version
   (`saas_alembic_version`); confirm your on-prem installer version matches it (your Permit contact
   can verify) before importing.
-- **Audit log history is not included.** Historical audit logs are not part of this package and are
-  retained by Permit Cloud only for a limited period — if you need them, request them from your
-  account team around the migration window.
 - **Very large organizations.** If the export returns **413 (too large)**, contact your account team
   — they run the export through an offline path and deliver the same package to you.
 
@@ -93,9 +90,6 @@ The migration data package contains a complete snapshot of your organization's d
   again and regain their workspace access on first login, provided they use the **same verified
   email address** they used in Permit Cloud (see
   [Team member access](#team-member-access-after-import))
-- **Audit log history** - not part of this package; request it from your account team if needed
-  (see [Step 0](#step-0-export-your-data-from-permit-cloud)). New audit logs start flowing as soon
-  as your on-prem deployment is running
 - **Runtime state** - PDPs re-register automatically, and generated policy is rebuilt from the
   imported data on startup
 

--- a/docs/how-to/deploy/on-prem/migrate-from-cloud.mdx
+++ b/docs/how-to/deploy/on-prem/migrate-from-cloud.mdx
@@ -186,19 +186,22 @@ the cause and simply run it again. psql prints `COPY <row-count>` for each table
 ```bash
 {
   echo '\set ON_ERROR_STOP on'
+  echo 'BEGIN;'
   echo "SET session_replication_role = 'replica';"
   jq -r '.import.tables_in_order[]' manifest.json | while read -r TABLE; do
     echo "\\COPY v2.${TABLE} FROM '/tmp/import/data/${TABLE}.csv' WITH CSV HEADER"
   done
-} | kubectl exec -i -n permit-platform $PG_POD -- psql -U permit -d permit --single-transaction
+  echo 'COMMIT;'
+} | kubectl exec -i -n permit-platform $PG_POD -- psql -U permit -d permit
 ```
 
-:::info Why referential checks are deferred
+:::info Why referential checks are turned off during the import
 Some Permit tables reference each other in both directions, so no import order can satisfy
-per-row referential checks - the import therefore defers them for this session
+per-row referential checks - the import therefore turns them off for this session
 (`session_replication_role`). This is safe: your package was exported as a single consistent
-database snapshot, so the data is guaranteed to be internally consistent. Use this technique
-only for this import - not for ad-hoc database changes.
+database snapshot. The one known exception - references to members who left your organization
+before the export - is cleaned up in step 6. Use this technique only for this import - not for
+ad-hoc database changes.
 :::
 
 ### 6. Clear references to departed members
@@ -240,7 +243,8 @@ kubectl exec -n permit-platform $PG_POD -- psql -U permit -d permit -c "
 UPDATE v2.v2_member SET is_superuser = true WHERE email = '<your-admin-email>';"
 ```
 
-Log out and log back in for the change to take effect.
+After you restart the services in step 9, log out and log back in for the change to take
+effect.
 
 :::caution Superuser applies platform-wide
 A superuser can see and manage **all** organizations on your deployment, not just the imported
@@ -253,9 +257,10 @@ one. Grant it only to your installation admin account.
 # Remove the import files from the pod
 kubectl exec -n permit-platform $PG_POD -- rm -rf /tmp/import
 
-# Scale the services back up (use the replica counts you noted in step 2)
-kubectl scale deployment -n permit-platform \
-  permit-backend-v2 celery-general permit-dl-enricher-v2 --replicas=1
+# Scale each service back to the replica count you noted in step 2
+kubectl scale deployment -n permit-platform permit-backend-v2 --replicas=<count-from-step-2>
+kubectl scale deployment -n permit-platform celery-general --replicas=<count-from-step-2>
+kubectl scale deployment -n permit-platform permit-dl-enricher-v2 --replicas=<count-from-step-2>
 ```
 
 ## Verify the Import
@@ -344,10 +349,11 @@ database is unchanged. Fix the cause shown in the error (usually a missing file 
 path), then run step 5 again from the start. If you are unsure of the state, roll back using
 the backup from step 3, or contact Permit support.
 
-### The import loop prints nothing
+### The import prints no `COPY` lines
 
-Your `manifest.json` predates the `import` section. Check the package `README.md` for the
-ready-to-run import script matching your package version, or contact Permit support.
+Your package was produced before manifests included the import list
+(`.import.tables_in_order`). Check the package `README.md` for the ready-to-run import script
+matching your package version, or contact Permit support.
 
 ### The imported organization is not visible in the UI
 

--- a/docs/how-to/deploy/on-prem/migrate-from-cloud.mdx
+++ b/docs/how-to/deploy/on-prem/migrate-from-cloud.mdx
@@ -177,48 +177,33 @@ kubectl exec -n permit-platform $PG_POD -- mkdir -p /tmp/import
 kubectl cp data permit-platform/$PG_POD:/tmp/import/data
 ```
 
-### 5. Import the data tables
+### 5. Import the data
 
-The manifest lists your tables in **dependency order** - tables that others reference are
-imported first, so every reference already exists when it is needed. (`v2_identity` and two
-tables handled in step 6 are deliberately not in this list.)
-
-The loop stops on the first failure instead of continuing with a partial import; psql prints
-`COPY <row-count>` for each successful table:
+The manifest lists every table to import (`v2_identity` is deliberately not in the list). The
+whole import runs as **one database transaction**: if anything fails, nothing is imported - fix
+the cause and simply run it again. psql prints `COPY <row-count>` for each table as it loads:
 
 ```bash
-for TABLE in $(jq -r '.import.tables_in_order[]' manifest.json); do
-  kubectl exec -n permit-platform $PG_POD -- psql -U permit -d permit -c \
-    "\COPY v2.${TABLE} FROM '/tmp/import/data/${TABLE}.csv' WITH CSV HEADER" \
-    && echo "imported: $TABLE" \
-    || { echo "FAILED on $TABLE - stop here and see Troubleshooting"; break; }
-done
+{
+  echo '\set ON_ERROR_STOP on'
+  echo "SET session_replication_role = 'replica';"
+  jq -r '.import.tables_in_order[]' manifest.json | while read -r TABLE; do
+    echo "\\COPY v2.${TABLE} FROM '/tmp/import/data/${TABLE}.csv' WITH CSV HEADER"
+  done
+} | kubectl exec -i -n permit-platform $PG_POD -- psql -U permit -d permit --single-transaction
 ```
 
-### 6. Import the API key and PDP configuration tables
-
-API keys can reference workspace members who left your organization before the export, and PDP
-configurations reference those API keys - so these two tables are imported with foreign-key
-checks temporarily disabled. The `SET` and the `\COPY` **must run in the same psql session**,
-which is why the commands are piped together:
-
-```bash
-for TABLE in $(jq -r '.import.fk_disabled_tables[]' manifest.json); do
-  (echo "SET session_replication_role = 'replica';" && \
-   echo "\COPY v2.${TABLE} FROM '/tmp/import/data/${TABLE}.csv' WITH CSV HEADER") | \
-  kubectl exec -i -n permit-platform $PG_POD -- psql -U permit -d permit \
-    && echo "imported: $TABLE" \
-    || { echo "FAILED on $TABLE - stop here and see Troubleshooting"; break; }
-done
-```
-
-:::caution Use this form only where shown
-`session_replication_role = 'replica'` bypasses foreign-key checks and triggers for the session.
-It is needed only for the tables listed in the manifest's `fk_disabled_tables`. If a table in
-step 5 fails, fix the cause (see Troubleshooting) - do not disable checks for it.
+:::info Why referential checks are deferred
+Some Permit tables reference each other in both directions, so no import order can satisfy
+per-row referential checks - the import therefore defers them for this session
+(`session_replication_role`). This is safe: your package was exported as a single consistent
+database snapshot, so the data is guaranteed to be internally consistent. Use this technique
+only for this import - not for ad-hoc database changes.
 :::
 
-Then clear any references to members that are not part of the imported data (these come from
+### 6. Clear references to departed members
+
+Clear any references to members that are not part of the imported data (these come from
 members who left your organization before the export):
 
 ```bash
@@ -352,18 +337,17 @@ instead of your on-prem deployment.
 
 ## Troubleshooting
 
-### A `\COPY` command fails partway through the import
+### The import fails partway through
 
-Each `\COPY` is atomic - a failed table imports zero rows, and the tables before it in the list
-are already fully imported. Fix the cause (usually a wrong file path or an out-of-order run),
-then resume the loop **from the table that failed**. Re-running an already-imported table fails
-with duplicate key errors without changing any data. If you are unsure of the state, roll back
-using the backup from step 3 and start over, or contact Permit support.
+The import runs in a single transaction, so a failure means **nothing was imported** - the
+database is unchanged. Fix the cause shown in the error (usually a missing file or a wrong
+path), then run step 5 again from the start. If you are unsure of the state, roll back using
+the backup from step 3, or contact Permit support.
 
-### `SET session_replication_role` appears to have no effect
+### The import loop prints nothing
 
-Each `kubectl exec` opens a new database session, and the setting only applies to the current
-session. Use the piped form shown in step 6 so the `SET` and the `\COPY` run in the same session.
+Your `manifest.json` predates the `import` section. Check the package `README.md` for the
+ready-to-run import script matching your package version, or contact Permit support.
 
 ### The imported organization is not visible in the UI
 

--- a/docs/how-to/deploy/on-prem/migrate-from-cloud.mdx
+++ b/docs/how-to/deploy/on-prem/migrate-from-cloud.mdx
@@ -45,27 +45,41 @@ rejected, because the package includes your API-key secrets.
 
 ### Download the package
 
-Call the export endpoint with that key. The organization is taken from the key, so you can only
-ever export your own organization:
+The export runs as a background job: you **start** it, **poll** until it's ready, then **download**
+from a short-lived link. The organization is taken from the key, so you can only ever export your
+own organization.
 
 ```bash
-curl -fSL \
-  -H "Authorization: Bearer permit_key_<your_org_api_key>" \
-  -o permit-migration.tar.gz \
-  "https://api.permit.io/v2/data-export"
+KEY="permit_key_<your_org_api_key>"
+
+# 1. Start the export — returns a task id
+TASK=$(curl -fsS -X POST -H "Authorization: Bearer $KEY" \
+  "https://api.permit.io/v2/data-export" | jq -r .task_id)
+
+# 2. Poll until "status" is "success" (it is "processing" while the package builds)
+curl -fsS -H "Authorization: Bearer $KEY" \
+  "https://api.permit.io/v2/data-export/$TASK"
+# -> {"status":"success","result":{"download_url":"https://…","expires_in_seconds":900, ...}}
+
+# 3. Download the package from the (short-lived) URL in result.download_url
+curl -fSL -o permit-migration.tar.gz "<download_url>"
 ```
 
-The response is your package: `permit-org-export-<org>-<timestamp>.tar.gz`. Extract it to get the
-`data/` directory and `manifest.json` referenced throughout this guide.
+Your package is `permit-org-export-<org>-<timestamp>.tar.gz`. Extract it to get the `data/`
+directory and `manifest.json` referenced throughout this guide.
 
+- **The download link is short-lived and secret.** It expires in a few minutes and grants access to
+  your package (which includes your API-key secrets) — download promptly and don't share it. If it
+  expires, poll the same task again for a fresh link.
 - **Freeze writes first (recommended).** Pause changes to your Permit Cloud workspace right before
   exporting, so the package captures your final state. The archive is a single consistent snapshot,
   but anything written *after* the export won't be in it.
 - **Version alignment.** The package's `manifest.json` records the source schema version
   (`saas_alembic_version`); confirm your on-prem installer version matches it (your Permit contact
   can verify) before importing.
-- **Very large organizations.** If the export returns **413 (too large)**, contact your account team
-  — they run the export through an offline path and deliver the same package to you.
+- **Very large organizations.** If the poll returns `"status":"failure"` because the export is too
+  large, contact your account team — they run the export through an offline path and deliver the same
+  package to you.
 
 :::caution Handle the package securely
 The package contains your API-key secrets. Store it securely, restrict access, and delete all copies

--- a/docs/how-to/deploy/on-prem/migrate-from-cloud.mdx
+++ b/docs/how-to/deploy/on-prem/migrate-from-cloud.mdx
@@ -1,0 +1,355 @@
+---
+title: "Migrate from Permit Cloud"
+description: "Import your Permit Cloud data into your on-premises deployment"
+---
+
+:::info Enterprise Only
+This section is only relevant to Enterprise customers who acquired an on-prem license.
+:::
+
+# Migrate from Permit Cloud to On-Premises
+
+This guide explains how to import your existing Permit Cloud (SaaS) data into your on-premises
+Permit Platform deployment, so you can switch environments without rebuilding your authorization
+model from scratch.
+
+Migration is a coordinated process: the Permit team exports your organization's data from Permit
+Cloud and delivers it to you as a **migration data package**. You then import that package into
+your own deployment using the steps below.
+
+## Requesting Your Migration Package
+
+Contact your Permit account team to schedule the migration. You will agree on:
+
+- **A migration window** - plan a short change freeze on your Permit Cloud workspace right before
+  the export, so the package captures your final state
+- **Audit log history** (optional) - historical audit logs are not part of the standard package.
+  If you want them, request them when scheduling: Permit Cloud retains audit logs for **90 days**,
+  so history that is not exported during the migration window cannot be recovered later
+- **Version alignment** - Permit confirms that your on-prem installer version matches the data
+  package (the package's `manifest.json` records the source schema version)
+
+Permit then performs the export and sends you a **secure, time-limited download link** to the
+package. Download it promptly - the link expires after a few days.
+
+## What Gets Migrated
+
+The migration data package contains a complete snapshot of your organization's data:
+
+- **Authorization model** - resources, actions, roles, permissions, relations, condition sets
+- **Directory data** - users, tenants, role assignments, relationship tuples, resource instances
+- **Configuration** - PDP configurations, webhooks, proxy configs, Permit Elements, email templates
+- **Workspace members** - your team members and their access levels
+- **API keys** - your existing `permit_key_*` tokens migrate as-is, so your applications keep
+  working without code changes after you point them at the on-prem endpoint
+
+**What is not migrated:**
+
+- **Login credentials** - on-prem uses its own identity provider (Keycloak). Team members sign in
+  again with the **same email address** they used in Permit Cloud and automatically regain their
+  workspace access (see [Team member access](#team-member-access-after-import))
+- **Audit log history** - optional, by request only (see
+  [Requesting Your Migration Package](#requesting-your-migration-package)). New audit logs start
+  flowing as soon as your on-prem deployment is running
+- **Runtime state** - PDPs re-register automatically, and generated policy is rebuilt from the
+  imported data on startup
+
+:::caution Handle the package securely
+The migration data package contains your API keys. Store it securely, restrict access to it, and
+delete all copies once the import is verified.
+:::
+
+## Package Contents
+
+```
+permit-migration-<org>-<date>/
+├── data/
+│   ├── v2_organization.csv
+│   ├── ... (one CSV per table)
+│   └── v2_identity.csv        # reference only - do NOT import (see below)
+├── manifest.json               # row counts + sha256 checksums for verification
+├── policy-repo/                # only if you used the default Permit-managed policy repo
+└── README.md
+```
+
+:::warning Do not import `v2_identity.csv`
+This file is a reference snapshot of your previous cloud login identities. It is intentionally
+excluded from the import steps below - importing it can prevent team members from regaining
+access when they first sign in to your on-prem deployment.
+:::
+
+### Policy repository
+
+Your policy-as-code (Rego) lives in a Git repository, not in the database:
+
+- **If you connected your own Git repository in Permit Cloud (GitOps)** - keep using it. Point
+  your on-prem deployment at the same repository in `values.yaml`
+- **If you used the default Permit-managed repository** - your package includes a `policy-repo/`
+  clone. Push it to a Git server you control and point your on-prem deployment at it, as
+  described in the package `README.md`
+
+Any custom Rego you wrote exists **only** in the Git repository - it is not part of the database
+import, so make sure the repository is connected before you rely on custom policies.
+
+## Prerequisites
+
+- A healthy on-premises Permit Platform deployment
+  (see the [Installation Guide](./installation.mdx)) - all pods `Running`, migrations job
+  `Completed`
+- The installer version confirmed by your Permit contact to match your migration data package
+- Access to the Kubernetes cluster with `kubectl` configured
+- The migration data package downloaded from the secure link provided by Permit
+
+## Step-by-Step Import
+
+### 1. Verify the package integrity
+
+Extract the package and verify every file against the manifest checksums:
+
+```bash
+tar -xzf permit-migration-<org>-<date>.tar.gz
+cd permit-migration-<org>-<date>/
+
+# Verify checksums (on macOS use: shasum -a 256 -c -)
+jq -r '.tables[] | "\(.sha256)  \(.file)"' manifest.json | sha256sum -c -
+```
+
+Every line should print `OK`. If any file fails verification, re-download the package before
+continuing.
+
+### 2. Stop services that write to the database
+
+Pause the platform services that write to PostgreSQL, so nothing changes mid-import:
+
+```bash
+kubectl scale deployment -n permit-platform \
+  permit-backend-v2 celery-general permit-dl-enricher-v2 --replicas=0
+```
+
+### 3. Back up the database
+
+Take a backup before importing, so you can roll back cleanly if anything goes wrong:
+
+```bash
+PG_POD=$(kubectl get pods -n permit-platform -l app=postgres \
+  --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}')
+
+kubectl exec -n permit-platform $PG_POD -- \
+  pg_dump -U permit -d permit -F c -f /tmp/pre-migration.dump
+kubectl cp permit-platform/$PG_POD:/tmp/pre-migration.dump ./pre-migration.dump
+kubectl exec -n permit-platform $PG_POD -- rm -f /tmp/pre-migration.dump
+```
+
+If your PostgreSQL runs outside the cluster, use your own snapshot mechanism instead.
+
+### 4. Copy the data files to the PostgreSQL pod
+
+```bash
+kubectl exec -n permit-platform $PG_POD -- mkdir -p /tmp/import
+kubectl cp data permit-platform/$PG_POD:/tmp/import/data
+```
+
+### 5. Import the data tables
+
+Import the tables in dependency order. Note that `v2_identity` is **not** in this list -
+that is intentional. The loop stops on the first failure instead of continuing with a partial
+import; psql prints `COPY <row-count>` for each successful table.
+
+```bash
+for TABLE in v2_organization v2_member v2_project v2_environment \
+             v2_resource v2_resource_action v2_resource_action_group \
+             v2_resource_action_group_association v2_resource_attribute \
+             v2_role v2_role_permission v2_role_hierarchy \
+             v2_role_derivations v2_role_derivation_rules \
+             v2_relation v2_condition_set v2_condition_set_rule \
+             v2_implicit_role_grant v2_group_role_permission \
+             v2_tenant v2_user v2_user_tenant_association \
+             v2_resource_instance v2_relationship_tuple v2_monthly_active_user \
+             v2_webhook v2_proxy_config \
+             v2_elements_config v2_elements_role_permission \
+             v2_elements_user_invite v2_email_configuration v2_email_template \
+             v2_sso_connection v2_policy_repo v2_scope_config \
+             v2_policy_guard_rule v2_policy_guard_scope \
+             v2_policy_guard_scope_detail v2_member_access \
+             v2_access_requests v2_user_invite; do
+  kubectl exec -n permit-platform $PG_POD -- psql -U permit -d permit -c \
+    "\COPY v2.${TABLE} FROM '/tmp/import/data/${TABLE}.csv' WITH CSV HEADER" \
+    && echo "imported: $TABLE" \
+    || { echo "FAILED on $TABLE - stop here and see Troubleshooting"; break; }
+done
+```
+
+### 6. Import the API key and PDP configuration tables
+
+`v2_api_key` can reference workspace members who are no longer part of your organization, and
+`v2_pdp_config` references those API keys - so both are imported with foreign-key checks
+temporarily disabled. The `SET` and the `\COPY` **must run in the same psql session**, which is
+why the commands are piped together:
+
+```bash
+for TABLE in v2_api_key v2_pdp_config; do
+  (echo "SET session_replication_role = 'replica';" && \
+   echo "\COPY v2.${TABLE} FROM '/tmp/import/data/${TABLE}.csv' WITH CSV HEADER") | \
+  kubectl exec -i -n permit-platform $PG_POD -- psql -U permit -d permit \
+    && echo "imported: $TABLE" \
+    || { echo "FAILED on $TABLE - stop here and see Troubleshooting"; break; }
+done
+```
+
+Then clear any references to members that are not part of the imported data (these come from
+members who left your organization before the export):
+
+```bash
+kubectl exec -n permit-platform $PG_POD -- psql -U permit -d permit -c "
+UPDATE v2.v2_api_key k SET created_by_member_id = NULL
+WHERE created_by_member_id IS NOT NULL
+AND NOT EXISTS (SELECT 1 FROM v2.v2_member m WHERE m.id = k.created_by_member_id);
+UPDATE v2.v2_user_invite ui SET member_id = NULL
+WHERE member_id IS NOT NULL
+AND NOT EXISTS (SELECT 1 FROM v2.v2_member m WHERE m.id = ui.member_id);"
+```
+
+### 7. Clear cloud-specific configuration
+
+Remove references that only apply to Permit Cloud:
+
+```bash
+kubectl exec -n permit-platform $PG_POD -- psql -U permit -d permit -c "
+UPDATE v2.v2_environment SET avp_policy_store_id = NULL
+WHERE avp_policy_store_id IS NOT NULL;"
+```
+
+After the import, also review these imported settings - they may carry over values that only
+made sense in Permit Cloud:
+
+- **SSO connections** - imported SSO settings reference the Permit Cloud login integration.
+  Reconfigure SSO against your on-prem Keycloak (or delete the stale entries)
+- **Webhooks** - your on-prem deployment sends webhooks from a different source IP; update
+  firewall allowlists on the receiving side if needed
+- **PDP configurations** - review any PDP settings that point at Permit Cloud endpoints
+
+### 8. Grant your admin access to the imported organization
+
+The admin account you created during installation is not a member of the imported organization
+yet. Make it a superuser so it can see and manage all organizations, including the imported one:
+
+```bash
+kubectl exec -n permit-platform $PG_POD -- psql -U permit -d permit -c "
+UPDATE v2.v2_member SET is_superuser = true WHERE email = '<your-admin-email>';"
+```
+
+Log out and log back in for the change to take effect.
+
+### 9. Clean up and restart
+
+```bash
+# Remove the import files from the pod
+kubectl exec -n permit-platform $PG_POD -- rm -rf /tmp/import
+
+# Scale the services back up
+kubectl scale deployment -n permit-platform \
+  permit-backend-v2 celery-general permit-dl-enricher-v2 --replicas=1
+```
+
+If you customized the replica counts in your `values.yaml`, scale back to your configured values
+instead of `1`.
+
+## Verify the Import
+
+Compare the imported row counts against the values in `manifest.json`. The counts must be
+filtered to your imported organization - your deployment may already contain other organizations
+(for example, the one created by your installation admin):
+
+```bash
+# Your organization id is recorded in the manifest
+ORG_ID=$(jq -r '.org_id' manifest.json)
+
+kubectl exec -n permit-platform $PG_POD -- psql -U permit -d permit -c "
+SELECT 'projects' AS table, count(*) FROM v2.v2_project WHERE org_id = '$ORG_ID'
+UNION ALL SELECT 'environments', count(*) FROM v2.v2_environment WHERE org_id = '$ORG_ID'
+UNION ALL SELECT 'users', count(*) FROM v2.v2_user WHERE org_id = '$ORG_ID'
+UNION ALL SELECT 'tenants', count(*) FROM v2.v2_tenant WHERE org_id = '$ORG_ID'
+UNION ALL SELECT 'roles', count(*) FROM v2.v2_role WHERE org_id = '$ORG_ID'
+UNION ALL SELECT 'relationship_tuples', count(*) FROM v2.v2_relationship_tuple WHERE org_id = '$ORG_ID'
+UNION ALL SELECT 'api_keys', count(*) FROM v2.v2_api_key WHERE org_id = '$ORG_ID';"
+```
+
+Then confirm in the UI:
+
+1. Log in to your on-prem dashboard as the admin - the imported organization should be visible
+2. Open the **Members** page - your team members appear with their original access levels
+3. Open the **Policy** page of a migrated environment - your resources, roles, and permissions
+   are present
+
+## Team Member Access After Import
+
+Your team members' profiles and permission levels are fully migrated. To sign in, each member
+authenticates against your on-prem identity provider (Keycloak) **using the same email address
+they used in Permit Cloud** - the platform automatically links them to their migrated profile and
+restores their workspace access on first login.
+
+Depending on how you configured Keycloak, members either:
+
+- **Sign in through your corporate SSO** (if you federated your IdP with Keycloak), or
+- **Self-register** on the on-prem login page with their work email
+
+:::caution Email verification is required
+The automatic account linking only happens for verified email addresses. Make sure email
+verification is enabled in your Keycloak realm (or that your federated IdP passes
+`email_verified=true`). A member who registers with a different or unverified email will start
+with a fresh account and no access.
+:::
+
+## Point Your Applications at On-Prem
+
+Your API keys were migrated as-is, so the only change your applications need is the endpoint:
+
+```python
+# Before (Permit Cloud)
+permit = Permit(
+    pdp="https://cloudpdp.api.permit.io",
+    token="permit_key_XXXX",
+)
+
+# After (On-Premises) - same key, new endpoint
+permit = Permit(
+    pdp="https://<your-permit-domain>",
+    token="permit_key_XXXX",
+)
+```
+
+## Troubleshooting
+
+### A `\COPY` command fails partway through the import
+
+Each `\COPY` is atomic - a failed table imports zero rows, and the tables before it in the list
+are already fully imported. Fix the cause (usually a wrong file path or an out-of-order run),
+then resume the loop **from the table that failed**. Re-running an already-imported table fails
+with duplicate key errors without changing any data. If you are unsure of the state, restore the
+backup from step 3 and start over, or contact Permit support.
+
+### `SET session_replication_role` appears to have no effect
+
+Each `kubectl exec` opens a new database session, and the setting only applies to the current
+session. Use the piped form shown in step 6 so the `SET` and the `\COPY` run in the same session.
+
+### The imported organization is not visible in the UI
+
+Complete step 8 (superuser grant), then log out and log back in. You can list all organizations
+with:
+
+```bash
+kubectl exec -n permit-platform $PG_POD -- psql -U permit -d permit -c \
+  "SELECT id, name, key FROM v2.v2_organization;"
+```
+
+### A team member logs in and sees an empty workspace
+
+Their login email does not match their Permit Cloud email, or their email is not verified. Check
+the email on the **Members** page, and verify your Keycloak realm has email verification enabled.
+
+## See Also
+
+- [Installation Guide](./installation.mdx)
+- [Management Guide](./management.mdx)
+- [Troubleshooting](./troubleshooting.mdx)

--- a/docs/how-to/deploy/on-prem/migrate-from-cloud.mdx
+++ b/docs/how-to/deploy/on-prem/migrate-from-cloud.mdx
@@ -142,8 +142,8 @@ kubectl get deployment -n permit-platform \
 Then pause these services so nothing changes mid-import:
 
 ```bash
-kubectl scale deployment -n permit-platform \
-  permit-backend-v2 celery-general permit-dl-enricher-v2 --replicas=0
+kubectl scale -n permit-platform --replicas=0 \
+  deployment/permit-backend-v2 deployment/celery-general deployment/permit-dl-enricher-v2
 ```
 
 ### 3. Back up the database
@@ -329,7 +329,7 @@ permit = Permit(
 # After (On-Premises) - same key, new endpoints
 permit = Permit(
     pdp="http://<your-pdp-address>:7766",        # the PDP you deployed on-prem
-    api_url="https://<your-permit-domain>/api",  # your on-prem Permit API
+    api_url="https://<your-permit-domain>",      # your on-prem Permit API
     token="permit_key_XXXX",
 )
 ```

--- a/docs/how-to/deploy/on-prem/migrate-from-cloud.mdx
+++ b/docs/how-to/deploy/on-prem/migrate-from-cloud.mdx
@@ -17,6 +17,15 @@ Migration is a coordinated process: the Permit team exports your organization's 
 Cloud and delivers it to you as a **migration data package**. You then import that package into
 your own deployment using the steps below.
 
+:::info At a glance
+The migration has five phases: **request the package** → **freeze & export** (done by Permit) →
+**import** (steps 1-9 below) → **verify** → **point your applications at on-prem**. Your on-prem
+platform is offline between steps 2 and 9 - for a typical organization the import itself takes
+well under an hour, and your Permit account team is available to assist during the window. You
+are done when the row counts match the manifest and the UI checks in
+[Verify the Import](#verify-the-import) pass.
+:::
+
 ## Requesting Your Migration Package
 
 Contact your Permit account team to schedule the migration. You will agree on:
@@ -24,13 +33,14 @@ Contact your Permit account team to schedule the migration. You will agree on:
 - **A migration window** - plan a short change freeze on your Permit Cloud workspace right before
   the export, so the package captures your final state
 - **Audit log history** (optional) - historical audit logs are not part of the standard package.
-  If you want them, request them when scheduling: Permit Cloud retains audit logs for **90 days**,
-  so history that is not exported during the migration window cannot be recovered later
+  Permit Cloud retains them for a limited period, so history that is not exported around the
+  migration window cannot be recovered later - if you want it, request it when scheduling and
+  confirm the retention window with your account team
 - **Version alignment** - Permit confirms that your on-prem installer version matches the data
   package (the package's `manifest.json` records the source schema version)
 
 Permit then performs the export and sends you a **secure, time-limited download link** to the
-package. Download it promptly - the link expires after a few days.
+package. Your Permit contact will tell you when the link expires - download it promptly.
 
 ## What Gets Migrated
 
@@ -40,14 +50,16 @@ The migration data package contains a complete snapshot of your organization's d
 - **Directory data** - users, tenants, role assignments, relationship tuples, resource instances
 - **Configuration** - PDP configurations, webhooks, proxy configs, Permit Elements, email templates
 - **Workspace members** - your team members and their access levels
-- **API keys** - your existing `permit_key_*` tokens migrate as-is, so your applications keep
-  working without code changes after you point them at the on-prem endpoint
+- **API keys** - your existing `permit_key_*` tokens migrate as-is; your applications keep using
+  the same keys and only the endpoints change (see
+  [Point Your Applications at On-Prem](#point-your-applications-at-on-prem))
 
 **What is not migrated:**
 
 - **Login credentials** - on-prem uses its own identity provider (Keycloak). Team members sign in
-  again with the **same email address** they used in Permit Cloud and automatically regain their
-  workspace access (see [Team member access](#team-member-access-after-import))
+  again and regain their workspace access on first login, provided they use the **same verified
+  email address** they used in Permit Cloud (see
+  [Team member access](#team-member-access-after-import))
 - **Audit log history** - optional, by request only (see
   [Requesting Your Migration Package](#requesting-your-migration-package)). New audit logs start
   flowing as soon as your on-prem deployment is running
@@ -64,10 +76,9 @@ delete all copies once the import is verified.
 ```
 permit-migration-<org>-<date>/
 ├── data/
-│   ├── v2_organization.csv
 │   ├── ... (one CSV per table)
 │   └── v2_identity.csv        # reference only - do NOT import (see below)
-├── manifest.json               # row counts + sha256 checksums for verification
+├── manifest.json               # row counts, checksums, and the import order
 ├── policy-repo/                # only if you used the default Permit-managed policy repo
 └── README.md
 ```
@@ -98,6 +109,8 @@ import, so make sure the repository is connected before you rely on custom polic
   `Completed`
 - The installer version confirmed by your Permit contact to match your migration data package
 - Access to the Kubernetes cluster with `kubectl` configured
+- `jq`, `tar`, and `sha256sum` (macOS: `shasum`) available on the workstation where you extract
+  the package
 - The migration data package downloaded from the secure link provided by Permit
 
 ## Step-by-Step Import
@@ -119,7 +132,14 @@ continuing.
 
 ### 2. Stop services that write to the database
 
-Pause the platform services that write to PostgreSQL, so nothing changes mid-import:
+First note the current replica counts, so you can restore them in step 9:
+
+```bash
+kubectl get deployment -n permit-platform \
+  permit-backend-v2 celery-general permit-dl-enricher-v2
+```
+
+Then pause these services so nothing changes mid-import:
 
 ```bash
 kubectl scale deployment -n permit-platform \
@@ -142,6 +162,14 @@ kubectl exec -n permit-platform $PG_POD -- rm -f /tmp/pre-migration.dump
 
 If your PostgreSQL runs outside the cluster, use your own snapshot mechanism instead.
 
+**To roll back later** (with the services still scaled to 0):
+
+```bash
+kubectl cp ./pre-migration.dump permit-platform/$PG_POD:/tmp/pre-migration.dump
+kubectl exec -n permit-platform $PG_POD -- \
+  pg_restore -U permit -d permit --clean --if-exists /tmp/pre-migration.dump
+```
+
 ### 4. Copy the data files to the PostgreSQL pod
 
 ```bash
@@ -151,27 +179,15 @@ kubectl cp data permit-platform/$PG_POD:/tmp/import/data
 
 ### 5. Import the data tables
 
-Import the tables in dependency order. Note that `v2_identity` is **not** in this list -
-that is intentional. The loop stops on the first failure instead of continuing with a partial
-import; psql prints `COPY <row-count>` for each successful table.
+The manifest lists your tables in **dependency order** - tables that others reference are
+imported first, so every reference already exists when it is needed. (`v2_identity` and two
+tables handled in step 6 are deliberately not in this list.)
+
+The loop stops on the first failure instead of continuing with a partial import; psql prints
+`COPY <row-count>` for each successful table:
 
 ```bash
-for TABLE in v2_organization v2_member v2_project v2_environment \
-             v2_resource v2_resource_action v2_resource_action_group \
-             v2_resource_action_group_association v2_resource_attribute \
-             v2_role v2_role_permission v2_role_hierarchy \
-             v2_role_derivations v2_role_derivation_rules \
-             v2_relation v2_condition_set v2_condition_set_rule \
-             v2_implicit_role_grant v2_group_role_permission \
-             v2_tenant v2_user v2_user_tenant_association \
-             v2_resource_instance v2_relationship_tuple v2_monthly_active_user \
-             v2_webhook v2_proxy_config \
-             v2_elements_config v2_elements_role_permission \
-             v2_elements_user_invite v2_email_configuration v2_email_template \
-             v2_sso_connection v2_policy_repo v2_scope_config \
-             v2_policy_guard_rule v2_policy_guard_scope \
-             v2_policy_guard_scope_detail v2_member_access \
-             v2_access_requests v2_user_invite; do
+for TABLE in $(jq -r '.import.tables_in_order[]' manifest.json); do
   kubectl exec -n permit-platform $PG_POD -- psql -U permit -d permit -c \
     "\COPY v2.${TABLE} FROM '/tmp/import/data/${TABLE}.csv' WITH CSV HEADER" \
     && echo "imported: $TABLE" \
@@ -181,13 +197,13 @@ done
 
 ### 6. Import the API key and PDP configuration tables
 
-`v2_api_key` can reference workspace members who are no longer part of your organization, and
-`v2_pdp_config` references those API keys - so both are imported with foreign-key checks
-temporarily disabled. The `SET` and the `\COPY` **must run in the same psql session**, which is
-why the commands are piped together:
+API keys can reference workspace members who left your organization before the export, and PDP
+configurations reference those API keys - so these two tables are imported with foreign-key
+checks temporarily disabled. The `SET` and the `\COPY` **must run in the same psql session**,
+which is why the commands are piped together:
 
 ```bash
-for TABLE in v2_api_key v2_pdp_config; do
+for TABLE in $(jq -r '.import.fk_disabled_tables[]' manifest.json); do
   (echo "SET session_replication_role = 'replica';" && \
    echo "\COPY v2.${TABLE} FROM '/tmp/import/data/${TABLE}.csv' WITH CSV HEADER") | \
   kubectl exec -i -n permit-platform $PG_POD -- psql -U permit -d permit \
@@ -195,6 +211,12 @@ for TABLE in v2_api_key v2_pdp_config; do
     || { echo "FAILED on $TABLE - stop here and see Troubleshooting"; break; }
 done
 ```
+
+:::caution Use this form only where shown
+`session_replication_role = 'replica'` bypasses foreign-key checks and triggers for the session.
+It is needed only for the tables listed in the manifest's `fk_disabled_tables`. If a table in
+step 5 fails, fix the cause (see Troubleshooting) - do not disable checks for it.
+:::
 
 Then clear any references to members that are not part of the imported data (these come from
 members who left your organization before the export):
@@ -209,18 +231,13 @@ WHERE member_id IS NOT NULL
 AND NOT EXISTS (SELECT 1 FROM v2.v2_member m WHERE m.id = ui.member_id);"
 ```
 
-### 7. Clear cloud-specific configuration
+### 7. Review cloud-specific configuration
 
-Remove references that only apply to Permit Cloud:
+Run the short cloud-reference cleanup included in your package (it removes settings that only
+apply to Permit Cloud) - see the **Cleanup** section of the package `README.md`.
 
-```bash
-kubectl exec -n permit-platform $PG_POD -- psql -U permit -d permit -c "
-UPDATE v2.v2_environment SET avp_policy_store_id = NULL
-WHERE avp_policy_store_id IS NOT NULL;"
-```
-
-After the import, also review these imported settings - they may carry over values that only
-made sense in Permit Cloud:
+Afterwards, review these imported settings - they may carry over values that only made sense in
+Permit Cloud:
 
 - **SSO connections** - imported SSO settings reference the Permit Cloud login integration.
   Reconfigure SSO against your on-prem Keycloak (or delete the stale entries)
@@ -240,19 +257,21 @@ UPDATE v2.v2_member SET is_superuser = true WHERE email = '<your-admin-email>';"
 
 Log out and log back in for the change to take effect.
 
+:::caution Superuser applies platform-wide
+A superuser can see and manage **all** organizations on your deployment, not just the imported
+one. Grant it only to your installation admin account.
+:::
+
 ### 9. Clean up and restart
 
 ```bash
 # Remove the import files from the pod
 kubectl exec -n permit-platform $PG_POD -- rm -rf /tmp/import
 
-# Scale the services back up
+# Scale the services back up (use the replica counts you noted in step 2)
 kubectl scale deployment -n permit-platform \
   permit-backend-v2 celery-general permit-dl-enricher-v2 --replicas=1
 ```
-
-If you customized the replica counts in your `values.yaml`, scale back to your configured values
-instead of `1`.
 
 ## Verify the Import
 
@@ -265,7 +284,7 @@ filtered to your imported organization - your deployment may already contain oth
 ORG_ID=$(jq -r '.org_id' manifest.json)
 
 kubectl exec -n permit-platform $PG_POD -- psql -U permit -d permit -c "
-SELECT 'projects' AS table, count(*) FROM v2.v2_project WHERE org_id = '$ORG_ID'
+SELECT 'projects' AS table_name, count(*) FROM v2.v2_project WHERE org_id = '$ORG_ID'
 UNION ALL SELECT 'environments', count(*) FROM v2.v2_environment WHERE org_id = '$ORG_ID'
 UNION ALL SELECT 'users', count(*) FROM v2.v2_user WHERE org_id = '$ORG_ID'
 UNION ALL SELECT 'tenants', count(*) FROM v2.v2_tenant WHERE org_id = '$ORG_ID'
@@ -302,7 +321,13 @@ with a fresh account and no access.
 
 ## Point Your Applications at On-Prem
 
-Your API keys were migrated as-is, so the only change your applications need is the endpoint:
+Your API keys were migrated as-is, so your applications keep using the same tokens - they just
+need to talk to your on-prem deployment instead of Permit Cloud. Two endpoints change:
+
+1. **The PDP address** - deploy a PDP against your on-prem platform (see
+   [PDP Deployment](./pdp-deployment.mdx)) and point your application at it
+2. **The API address** - point the SDK's API URL at your on-prem platform, so management calls
+   (like syncing users) reach your deployment and not Permit Cloud
 
 ```python
 # Before (Permit Cloud)
@@ -311,12 +336,19 @@ permit = Permit(
     token="permit_key_XXXX",
 )
 
-# After (On-Premises) - same key, new endpoint
+# After (On-Premises) - same key, new endpoints
 permit = Permit(
-    pdp="https://<your-permit-domain>",
+    pdp="http://<your-pdp-address>:7766",        # the PDP you deployed on-prem
+    api_url="https://<your-permit-domain>/api",  # your on-prem Permit API
     token="permit_key_XXXX",
 )
 ```
+
+:::caution Do not skip the API URL
+If `api_url` still points at Permit Cloud, your migrated API keys remain valid there - your
+application would silently keep writing users and permissions to your old cloud workspace
+instead of your on-prem deployment.
+:::
 
 ## Troubleshooting
 
@@ -325,8 +357,8 @@ permit = Permit(
 Each `\COPY` is atomic - a failed table imports zero rows, and the tables before it in the list
 are already fully imported. Fix the cause (usually a wrong file path or an out-of-order run),
 then resume the loop **from the table that failed**. Re-running an already-imported table fails
-with duplicate key errors without changing any data. If you are unsure of the state, restore the
-backup from step 3 and start over, or contact Permit support.
+with duplicate key errors without changing any data. If you are unsure of the state, roll back
+using the backup from step 3 and start over, or contact Permit support.
 
 ### `SET session_replication_role` appears to have no effect
 
@@ -348,8 +380,16 @@ kubectl exec -n permit-platform $PG_POD -- psql -U permit -d permit -c \
 Their login email does not match their Permit Cloud email, or their email is not verified. Check
 the email on the **Members** page, and verify your Keycloak realm has email verification enabled.
 
+## Support
+
+Need help with your migration?
+
+- 📧 **Email**: [support@permit.io](mailto:support@permit.io)
+- 💬 **Slack**: [Join our community](https://io.permit.io/slack)
+
 ## See Also
 
 - [Installation Guide](./installation.mdx)
+- [PDP Deployment](./pdp-deployment.mdx)
 - [Management Guide](./management.mdx)
 - [Troubleshooting](./troubleshooting.mdx)

--- a/docs/how-to/deploy/on-prem/migrate-from-cloud.mdx
+++ b/docs/how-to/deploy/on-prem/migrate-from-cloud.mdx
@@ -9,38 +9,71 @@ This section is only relevant to Enterprise customers who acquired an on-prem li
 
 # Migrate from Permit Cloud to On-Premises
 
-This guide explains how to import your existing Permit Cloud (SaaS) data into your on-premises
-Permit Platform deployment, so you can switch environments without rebuilding your authorization
-model from scratch.
+This guide explains how to export your existing Permit Cloud (SaaS) data and import it into your
+on-premises Permit Platform deployment, so you can switch environments without rebuilding your
+authorization model from scratch.
 
-Migration is a coordinated process: the Permit team exports your organization's data from Permit
-Cloud and delivers it to you as a **migration data package**. You then import that package into
-your own deployment using the steps below.
+You run the migration yourself, end to end: you **export** your organization's data from Permit
+Cloud with your own API key (it downloads as a single **migration data package**), then **import**
+that package into your own deployment using the steps below. Your Permit account team is available
+to assist — and for very large organizations they can run the export for you — but no Permit
+involvement is required.
 
 :::info At a glance
-The migration has five phases: **request the package** → **freeze & export** (done by Permit) →
+The migration has four phases: **export your data** ([Step 0](#step-0-export-your-data-from-permit-cloud)) →
 **import** (steps 1-9 below) → **verify** → **point your applications at on-prem**. Your on-prem
-platform is offline between steps 2 and 9 - for a typical organization the import itself takes
-well under an hour, and your Permit account team is available to assist during the window. You
-are done when the row counts match the manifest and the UI checks in
+platform is offline between import steps 2 and 9 - for a typical organization the import itself
+takes well under an hour. You are done when the row counts match the manifest and the UI checks in
 [Verify the Import](#verify-the-import) pass.
 :::
 
-## Requesting Your Migration Package
+## Step 0: Export Your Data from Permit Cloud
 
-Contact your Permit account team to schedule the migration. You will agree on:
+You export your organization's data yourself, using an **Organization API key**. The export streams
+a single `tar.gz` **migration data package** (one CSV per table plus a `manifest.json`), scoped to
+your organization only.
 
-- **A migration window** - plan a short change freeze on your Permit Cloud workspace right before
-  the export, so the package captures your final state
-- **Audit log history** (optional) - historical audit logs are not part of the standard package.
-  Permit Cloud retains them for a limited period, so history that is not exported around the
-  migration window cannot be recovered later - if you want it, request it when scheduling and
-  confirm the retention window with your account team
-- **Version alignment** - Permit confirms that your on-prem installer version matches the data
-  package (the package's `manifest.json` records the source schema version)
+### Generate an Organization API key
 
-Permit then performs the export and sends you a **secure, time-limited download link** to the
-package. Your Permit contact will tell you when the link expires - download it promptly.
+The export requires an **Organization-level API key with management access** — a read-only key is
+rejected, because the package includes your API-key secrets.
+
+1. In the Permit Cloud dashboard, open **Settings → API Keys**.
+2. Create an **Organization** API key (not a project- or environment-scoped one) with an
+   admin/management access level.
+3. Copy the `permit_key_...` value — you will pass it as a Bearer token below.
+
+### Download the package
+
+Call the export endpoint with that key. The organization is taken from the key, so you can only
+ever export your own organization:
+
+```bash
+curl -fSL \
+  -H "Authorization: Bearer permit_key_<your_org_api_key>" \
+  -o permit-migration.tar.gz \
+  "https://api.permit.io/v2/data-export"
+```
+
+The response is your package: `permit-org-export-<org>-<timestamp>.tar.gz`. Extract it to get the
+`data/` directory and `manifest.json` referenced throughout this guide.
+
+- **Freeze writes first (recommended).** Pause changes to your Permit Cloud workspace right before
+  exporting, so the package captures your final state. The archive is a single consistent snapshot,
+  but anything written *after* the export won't be in it.
+- **Version alignment.** The package's `manifest.json` records the source schema version
+  (`saas_alembic_version`); confirm your on-prem installer version matches it (your Permit contact
+  can verify) before importing.
+- **Audit log history is not included.** Historical audit logs are not part of this package and are
+  retained by Permit Cloud only for a limited period — if you need them, request them from your
+  account team around the migration window.
+- **Very large organizations.** If the export returns **413 (too large)**, contact your account team
+  — they run the export through an offline path and deliver the same package to you.
+
+:::caution Handle the package securely
+The package contains your API-key secrets. Store it securely, restrict access, and delete all copies
+once the import is verified.
+:::
 
 ## What Gets Migrated
 
@@ -60,27 +93,22 @@ The migration data package contains a complete snapshot of your organization's d
   again and regain their workspace access on first login, provided they use the **same verified
   email address** they used in Permit Cloud (see
   [Team member access](#team-member-access-after-import))
-- **Audit log history** - optional, by request only (see
-  [Requesting Your Migration Package](#requesting-your-migration-package)). New audit logs start
-  flowing as soon as your on-prem deployment is running
+- **Audit log history** - not part of this package; request it from your account team if needed
+  (see [Step 0](#step-0-export-your-data-from-permit-cloud)). New audit logs start flowing as soon
+  as your on-prem deployment is running
 - **Runtime state** - PDPs re-register automatically, and generated policy is rebuilt from the
   imported data on startup
 
-:::caution Handle the package securely
-The migration data package contains your API keys. Store it securely, restrict access to it, and
-delete all copies once the import is verified.
-:::
-
 ## Package Contents
 
+The exported `tar.gz` contains one CSV per table plus a manifest:
+
 ```
-permit-migration-<org>-<date>/
+permit-org-export-<org>-<timestamp>/
 ├── data/
 │   ├── ... (one CSV per table)
 │   └── v2_identity.csv        # reference only - do NOT import (see below)
-├── manifest.json               # row counts, checksums, and the import order
-├── policy-repo/                # only if you used the default Permit-managed policy repo
-└── README.md
+└── manifest.json               # row counts, checksums, and the import order
 ```
 
 :::warning Do not import `v2_identity.csv`
@@ -91,13 +119,14 @@ access when they first sign in to your on-prem deployment.
 
 ### Policy repository
 
-Your policy-as-code (Rego) lives in a Git repository, not in the database:
+Your policy-as-code (Rego) lives in a Git repository, not in the database, so it is **not** part of
+the exported package:
 
 - **If you connected your own Git repository in Permit Cloud (GitOps)** - keep using it. Point
   your on-prem deployment at the same repository in `values.yaml`
-- **If you used the default Permit-managed repository** - your package includes a `policy-repo/`
-  clone. Push it to a Git server you control and point your on-prem deployment at it, as
-  described in the package `README.md`
+- **If you used the default Permit-managed repository** - your Rego lives in a repository Permit
+  hosts. Ask your account team for a clone of it, then push it to a Git server you control and point
+  your on-prem deployment at that repository
 
 Any custom Rego you wrote exists **only** in the Git repository - it is not part of the database
 import, so make sure the repository is connected before you rely on custom policies.
@@ -111,7 +140,7 @@ import, so make sure the repository is connected before you rely on custom polic
 - Access to the Kubernetes cluster with `kubectl` configured
 - `jq`, `tar`, and `sha256sum` (macOS: `shasum`) available on the workstation where you extract
   the package
-- The migration data package downloaded from the secure link provided by Permit
+- The migration data package exported in [Step 0](#step-0-export-your-data-from-permit-cloud)
 
 ## Step-by-Step Import
 
@@ -120,8 +149,8 @@ import, so make sure the repository is connected before you rely on custom polic
 Extract the package and verify every file against the manifest checksums:
 
 ```bash
-tar -xzf permit-migration-<org>-<date>.tar.gz
-cd permit-migration-<org>-<date>/
+tar -xzf permit-migration.tar.gz
+cd permit-org-export-<org>-<timestamp>/
 
 # Verify checksums (on macOS use: shasum -a 256 -c -)
 jq -r '.tables[] | "\(.sha256)  \(.file)"' manifest.json | sha256sum -c -
@@ -221,14 +250,12 @@ AND NOT EXISTS (SELECT 1 FROM v2.v2_member m WHERE m.id = ui.member_id);"
 
 ### 7. Review cloud-specific configuration
 
-Run the short cloud-reference cleanup included in your package (it removes settings that only
-apply to Permit Cloud) - see the **Cleanup** section of the package `README.md`.
+Some imported settings carry over values that only made sense in Permit Cloud - review and adjust
+them for your deployment:
 
-Afterwards, review these imported settings - they may carry over values that only made sense in
-Permit Cloud:
-
-- **SSO connections** - imported SSO settings reference the Permit Cloud login integration.
-  Reconfigure SSO against your on-prem Keycloak (or delete the stale entries)
+- **SSO connections** - your SSO configuration lives with Permit Cloud's login integration, not in
+  the database, so the imported `v2_sso_connection` rows only point at it. Reconfigure SSO against
+  your on-prem Keycloak (or delete the stale entries)
 - **Webhooks** - your on-prem deployment sends webhooks from a different source IP; update
   firewall allowlists on the receiving side if needed
 - **PDP configurations** - review any PDP settings that point at Permit Cloud endpoints
@@ -351,9 +378,9 @@ the backup from step 3, or contact Permit support.
 
 ### The import prints no `COPY` lines
 
-Your package was produced before manifests included the import list
-(`.import.tables_in_order`). Check the package `README.md` for the ready-to-run import script
-matching your package version, or contact Permit support.
+The import loop reads the table list from `manifest.json` (`.import.tables_in_order`). If that field
+is empty, confirm `jq` is installed and that you are pointing at the extracted package's
+`manifest.json`, or contact Permit support.
 
 ### The imported organization is not visible in the UI
 


### PR DESCRIPTION
### Summary

Adds a customer-facing guide to the On-Premises Deployment section for migrating from Permit Cloud (SaaS) to a self-hosted deployment. The customer runs the whole migration **themselves, end to end**:

- **Export** their organization's data from Permit Cloud with their own **Organization API key** — `POST /v2/data-export` starts a background job, they poll `GET /v2/data-export/{task_id}` until it's ready, then download the `tar.gz` package from a short-lived link.
- **Import** that package into their own on-prem Permit Platform (single-transaction, FK-deferred, from the package manifest).

No Permit-side tooling or internal process is exposed — the page is scoped to the customer's self-service flow and their own cluster.

### Linear Issue

PER-14389

### Changes

- **`docs/how-to/deploy/on-prem/migrate-from-cloud.mdx`** (new page, picked up by the autogenerated on-prem sidebar):
  - **Step 0 — Export Your Data from Permit Cloud**: generate an Organization API key with management access (Settings → API Keys; read-only keys are rejected), then **start → poll → download**: `POST /v2/data-export` returns a task id, `GET /v2/data-export/{task_id}` polls until `success` and returns a short-lived presigned `download_url`. Notes that the link is short-lived + secret, plus write-freeze, version alignment (`manifest.saas_alembic_version`), and the too-large case (surfaces as a poll failure).
  - **Package layout**: `data/` (one CSV per table) + `manifest.json`; `v2_identity.csv` is reference-only and never imported; policy-as-code lives in Git, not the package.
  - **Import (steps 1–9)**: checksum verification against the manifest, pre-import DB backup, write-freeze (verified chart deployment names), single-transaction FK-deferred import driven by `manifest.import.tables_in_order`, dangling-member cleanup, cloud-specific config review (SSO/webhooks/PDP), admin superuser grant.
  - **Verify** (org-filtered row counts vs `manifest.json` + UI checks), **Team member access** (Keycloak email-linking, verified-email requirement), **Point applications at on-prem** (SDK `api_url` cutover), **Troubleshooting**.
- One-line companion fix in `management.mdx`: backend health check `/api/v2/health` → `/v2/healthy` (the backend route is `/healthy` under the `/v2` prefix).

### Scope / boundary

- **Self-service export** — the customer exports their own org with their own API key; the org is derived from the key, so a key can only ever export its own org.
- **No internal content** — the page contains none of Permit's internal migration tooling (the sysadmin export endpoint, Bytebase, prod-US/Aurora, RDS reader endpoints, pgbouncer). Only the public `api.permit.io/v2/data-export` endpoint and the customer's own `permit-platform`-namespace `kubectl` commands appear.
- **RDS data only** — no audit-log / OpenSearch history content (the page does not reference exporting or requesting historical logs).

### Review

- **Multi-agent deep review with a customer-facing lens (2026-07-23):** verdict **READY**, no blocking findings.
  - Zero internal leaks (grepped Bytebase / prod-US/EU / Aurora / RDS / sysadmin / pgbouncer / staging — none present).
  - Zero audit-log / OpenSearch references remain.
  - MDX valid (frontmatter, balanced admonitions, no raw `<…>` outside code fences), all internal anchors and sibling-file links resolve.
  - Export instructions verified against the backend code (`data_export.py`): endpoint path, Bearer API-key auth, org-from-key scoping, management-access gate (read-only → 403), 413 path, and every manifest field the import steps consume.
- Earlier rounds: `api_url` `/api`-prefix fix (Zeev), `kubectl scale` portability (Copilot), and verification of chart deployment names / postgres pod label / DB name+user / `session_replication_role` bootstrap against the platform Helm chart and backend source.

### Test plan

- [x] Multi-agent deep review, customer-facing lens — READY (no internal leaks, MDX valid, anchors/links resolve)
- [x] Export instructions cross-checked against the live `/v2/data-export` endpoint + manifest schema
- [x] Import commands verified against the on-prem Helm chart (deployment names, postgres pod label, DB name/user, namespace) and backend source
- [x] No references to internal tooling (sysadmin endpoint, Bytebase, Permit infra) and no audit-log/OpenSearch content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

