### PR TITLE
PER-15560: document drift-block recovery (user-driven reconsent) for the HTTP Egress Proxy

### DIFF
--- a/docs/permit-mcp-gateway/http-egress-proxy/cli.mdx
+++ b/docs/permit-mcp-gateway/http-egress-proxy/cli.mdx
@@ -107,7 +107,7 @@ Exit codes are stable:
 | `asg proxy ca status\|download\|rotate\|trust-shell` | Manage the per-host TLS-interception certificate authority. See [Connecting Agents](./connecting-agents#https-interception). |
 | `asg proxy doctor <host>` | Diagnose proxy setup end to end. |
 
-Run `asg proxy <command> --help` for the full flag list of any command. `asg proxy --help` also lists preset packs (`asg proxy preset list` browses the built-in catalog) and two opt-in capabilities: **agent identity registration** (see [Agent Verification](/permit-mcp-gateway/advanced-features)) and the **intent guardian**, which judges each request against an operator-declared task description. [Contact us](mailto:support@permit.io) to enable the opt-in capabilities for your account.
+Run `asg proxy <command> --help` for the full flag list of any command. `asg proxy --help` also lists preset packs (`asg proxy preset list` browses the built-in catalog) and two opt-in capabilities. **Agent identity registration** has agents declare their session intent with `asg proxy register-session`; a drift-blocked session is recovered by the agent's own user through a browser re-approval link — see [Security → Agent identity and drift protection](./security#agent-identity-and-drift-protection). The **intent guardian** judges each request against an operator-declared task description. [Contact us](mailto:support@permit.io) to enable the opt-in capabilities for your account.
 
 ## Passing the host subdomain
 

--- a/docs/permit-mcp-gateway/http-egress-proxy/connecting-agents.mdx
+++ b/docs/permit-mcp-gateway/http-egress-proxy/connecting-agents.mdx
@@ -86,6 +86,7 @@ asg proxy doctor acme
 - Your local proxy environment variables
 - The interception CA's status and expiry, and whether your environment trusts it
 - The token file's permissions and the token's expiry
+- When [agent identity](./security#agent-identity-and-drift-protection) is enabled: whether the agent has registered a session — and whether that session is **drift-blocked**, in which case the check fails with the re-approval link that clears it
 
 Each check reports **pass**, **warn**, or **fail**; anything that isn't a pass carries a suggested fix. `doctor` exits `0` (clean), `1` (operator-fixable failure), or `2` (gateway fault), so it's safe to gate CI on — and it's the first thing to run whenever an agent's traffic isn't behaving.
 

--- a/docs/permit-mcp-gateway/http-egress-proxy/egress-rules.mdx
+++ b/docs/permit-mcp-gateway/http-egress-proxy/egress-rules.mdx
@@ -97,7 +97,7 @@ Begin with the exact domains and paths your agents need at the lowest trust that
 For high-risk egress, the gateway can route a request to a human for approval before it's forwarded — the same [Human-in-the-Loop](/permit-mcp-gateway/human-in-the-loop) machinery it uses for MCP tool calls. This is an optional capability; [contact us](mailto:support@permit.io) to enable it for your account. A few things to know about when it applies:
 
 - Approval is triggered by the intent **guardian**'s verdict on a request — not by a rule setting or a risk score.
-- It requires the host to have **both** agent identity and the guardian enabled.
+- It requires the host to have **both** [agent identity](./security#agent-identity-and-drift-protection) and the guardian enabled.
 - It applies to plain HTTP and to HTTPS on rules evaluated in `intercept` mode. Traffic inside a default `passthrough` tunnel is opaque to the proxy and is **never** routed for approval.
 
 When an approval is required, the request pauses at the proxy, your reviewers are notified (email / Slack), and it proceeds only if a reviewer approves — otherwise it's denied (fail-closed). When an agent is driven by the CLI, approval outcomes are reported distinctly so automation can tell *"a human said no"* from *"blocked by policy"* from *"the request timed out."*

--- a/docs/permit-mcp-gateway/http-egress-proxy/index.mdx
+++ b/docs/permit-mcp-gateway/http-egress-proxy/index.mdx
@@ -38,6 +38,7 @@ The HTTP Egress Proxy puts the same deny-by-default, identity-aware control plan
 | **Server-side credentials** | Upstream API keys, tokens, and OAuth connections are stored in the gateway (encrypted at rest when the KMS vault is enabled) and injected into requests on the way out. The agent never sees them. |
 | **Human consent & trust ceilings** | Just like MCP, a human can delegate egress access to an agent within an admin-defined trust ceiling — and revoke it at any time. |
 | **Human-in-the-loop** | High-risk requests can be routed to a human for approval before they're forwarded (optional, per host). |
+| **Agent identity & drift protection** | Each agent session registers its task intent; a sharp change in declared intent blocks the session until it is re-approved — by the person who authorized the agent, in the browser (opt-in). See [Security](./security#agent-identity-and-drift-protection). |
 | **SSRF protection** | Internal IP literals and known cluster-internal hostnames are rejected before any DNS lookup; a hostname that resolves into a private, loopback, link-local, or metadata range is rejected after resolution and before any connection. |
 | **Response scrubbing** | Injected secrets are stripped (best-effort, on by default) from upstream responses before they reach the agent. |
 | **Rate limiting** | Per-agent request budgets — by host and by domain — shed floods and contain runaway agents. |
@@ -96,7 +97,7 @@ Every outbound request runs through the same ordered set of checks. Cheap, fail-
 7. **Trust ceiling** — for human-delegated agents, the effective access is capped at the trust level that human granted for the workflow.
 8. **Forward** — the matched credential is injected, the request is sent, and the response is scrubbed of any injected secret before returning to the agent. *(Injection and scrubbing apply to plain HTTP and to HTTPS in `intercept` mode; a `passthrough` tunnel is forwarded opaquely.)*
 
-For the detail behind each gate, see [Authorization & Trust](./authorization) and [Security](./security).
+For the detail behind each gate, see [Authorization & Trust](./authorization) and [Security](./security). Hosts with the opt-in [agent identity capability](./security#agent-identity-and-drift-protection) enabled additionally require a registered agent session before governed traffic flows.
 
 ---
 
@@ -108,4 +109,4 @@ For the detail behind each gate, see [Authorization & Trust](./authorization) an
 4. [**Credentials & Connections**](./credentials) — store upstream secrets and connect OAuth providers.
 5. [**Authorization & Trust**](./authorization) — how rules, Permit policy, and human consent compose.
 6. [**Connecting Agents**](./connecting-agents) — wire your agent runtime, Docker, or Kubernetes to the proxy.
-7. [**Security**](./security) — SSRF protection, credential isolation, response scrubbing, TLS modes, and rate limits.
+7. [**Security**](./security) — SSRF protection, credential isolation, response scrubbing, TLS modes, agent identity and drift protection, and rate limits.

--- a/docs/permit-mcp-gateway/http-egress-proxy/quickstart.mdx
+++ b/docs/permit-mcp-gateway/http-egress-proxy/quickstart.mdx
@@ -140,7 +140,7 @@ If something isn't working, run the built-in diagnostics:
 asg proxy doctor acme
 ```
 
-`doctor` checks gateway reachability, whether the proxy is enabled, your stored-credential count, your local environment variables, the interception CA's status, and your token file's permissions and expiry — each as **pass**, **warn**, or **fail** with a suggested fix.
+`doctor` checks gateway reachability, whether the proxy is enabled, your stored-credential count, your local environment variables, the interception CA's status, your token file's permissions and expiry, and — when [agent identity](./security#agent-identity-and-drift-protection) is enabled — the agent's session registration and drift-block state. Each check reports **pass**, **warn**, or **fail** with a suggested fix.
 
 ---
 

--- a/docs/permit-mcp-gateway/http-egress-proxy/security.mdx
+++ b/docs/permit-mcp-gateway/http-egress-proxy/security.mdx
@@ -1,7 +1,7 @@
 ---
 title: Security
 sidebar_label: Security
-description: The security properties of the HTTP Egress Proxy — SSRF protection, server-side credential isolation, response scrubbing, TLS modes, rate limiting, and audit — and the preconditions each one depends on.
+description: The security properties of the HTTP Egress Proxy — SSRF protection, server-side credential isolation, response scrubbing, TLS modes, agent identity and drift protection, rate limiting, and audit — and the preconditions each one depends on.
 sidebar_position: 7
 ---
 
@@ -57,6 +57,25 @@ Because only the tunnel rule is consulted at set-up, TLS mode is effectively **p
 The proxy meters every request that reaches a matching workflow rule against per-agent budgets — per **host** (600 requests / 60s by default) and per **registrable domain** (1200 / 60s) — and sheds excess with a `429` and a `Retry-After`. These budgets run before the policy and approval checks, so a flood is rejected cheaply. Additional bounds — token-size caps, slow-client timeouts, and a ceiling on concurrent connections — protect the proxy itself.
 
 Note that if the counter store is unreachable the limiter **fails open** (requests are allowed), so treat rate limiting as availability protection rather than a hard security boundary.
+
+## Agent identity and drift protection
+
+*(Opt-in — [contact us](mailto:support@permit.io) to enable it for your account.)*
+
+A host can additionally require every agent session to **register its intent**: before its first governed request, the agent declares what it is working on, in exactly twelve distinct words, with [`asg proxy register-session`](./cli). The gateway builds a behavioral baseline from those declarations, and a sharp change in an agent's declared intent — the signature of a hijacked or steered agent — **blocks the session**: registrations and governed requests are denied until a human re-approves the agent.
+
+**Recovery is user-driven.** The block response the agent receives carries a **re-approval link** to your gateway's own consent screen (`/reconsent-agent`). The agent is instructed to show that link to the person running it — never to open it itself. That person signs in (a recent sign-in, within the last day, is required), reviews **what the agent last declared it was doing**, and decides:
+
+- **Re-approve** — the block lifts, and the agent's next registration starts a clean baseline.
+- **Keep blocked** — nothing changes; the agent stays denied.
+
+Only the account that originally authorized the agent can unblock it — a link forwarded to anyone else shows an error instead of the review screen. Completing a fresh consent flow ([`asg proxy authorize`](./authorization#human-consent)) clears the block the same way. An operator can always clear a block with `asg proxy identity reconsent` — and for automated agents running under an operator-minted token (no human delegation), that is the only recovery path. Re-approvals — by the user or by an operator — are recorded in the [audit trail](#audit-trail), including who cleared the block.
+
+:::tip Review before you re-approve
+The review screen shows the agent's own declared intent — the words that tripped the block. If they don't match what you asked the agent to do, keep it blocked and investigate: a drift block is often the first visible sign of prompt injection.
+:::
+
+[`asg proxy doctor`](./connecting-agents#diagnose-with-doctor) reports a drift-blocked session as a failing check, with the same re-approval link. For the background on agent identity and drift detection, see [Agent Verification](/permit-mcp-gateway/advanced-features#agent-verification).
 
 ## Audit trail
 


### PR DESCRIPTION
## Why

PER-15560 (permitio/agent-security#477, merged) changed how a drift-blocked agent session recovers on the HTTP Egress Proxy: recovery is now **user-driven** — the block response carries a re-approval link to the tenant's consent screen, where the person who authorized the agent reviews its last declared intent and re-approves it (or keeps it blocked). Previously recovery was operator-only. The customer docs under `http-egress-proxy` did not describe the identity capability's behavior at all, so a customer with the opt-in enabled had no reference for what a drift block is or how to clear one.

## What

- **security.mdx** — new **Agent identity and drift protection** section (marked opt-in / contact-us, matching the section's convention): session intent registration (`asg proxy register-session`, twelve distinct words), what triggers a block, the browser recovery flow (re-approval link → signed-in review of the agent's declared intent → Re-approve / Keep blocked), who can unblock (self-scope; fresh consent flow; operator override `asg proxy identity reconsent`), audit note, and a review-before-you-reapprove tip.
- **index.mdx** — capability-table row, a note on the governed-request pipeline, and the Security entry in the section list now mention the capability.
- **cli.mdx** — the opt-in capabilities paragraph now names `register-session` and the recovery link.
- **connecting-agents.mdx** + **quickstart.mdx** — `asg proxy doctor` docs gain the drift-block check (fails with the re-approval link).
- **egress-rules.mdx** — the HITL prerequisite mention of agent identity now links to the new section.

Deliberately **not** documented (customer-appropriateness): drift thresholds and detection internals, protocol/status-code details, internal service names, and full syntax for the opt-in commands (the section's established pattern keeps opt-in detail behind contact-us).

## Review

- Full site build green: 48,644 links checked, **0 bad links, 0 bad anchors**.
- A dedicated accuracy + leakage review verified every product claim against the shipped implementation (twelve-word rule, day-fresh sign-in requirement, self-scoped unblock, operator override command, doctor behavior) and confirmed no internal details leak. Its findings (audit-trail overpromise, operator-override scoping, stale page-content enumerations, link-anchor precision) are incorporated.

Linear: PER-15560

🤖 Generated with [Claude Code](https://claude.com/claude-code)